### PR TITLE
Lightclient protocol v0.4.0 - database implementation changes

### DIFF
--- a/zaino-fetch/src/chain/transaction.rs
+++ b/zaino-fetch/src/chain/transaction.rs
@@ -1194,7 +1194,7 @@ impl FullTransaction {
             vec![]
         };
 
-        let vout = if pool_types.includes_tranparent() {
+        let vout = if pool_types.includes_transparent() {
             self.raw_transaction
                 .transparent_outputs
                 .iter()
@@ -1207,7 +1207,7 @@ impl FullTransaction {
             vec![]
         };
 
-        let vin = if pool_types.includes_tranparent() {
+        let vin = if pool_types.includes_transparent() {
             self.raw_transaction
                 .transparent_inputs
                 .iter()

--- a/zaino-proto/src/proto/utils.rs
+++ b/zaino-proto/src/proto/utils.rs
@@ -220,6 +220,27 @@ impl PoolTypeFilter {
         self.include_orchard
     }
 
+    /// Convert this filter into the corresponding `Vec<PoolType>`.
+    ///
+    /// The resulting vector contains each included pool type at most once.
+    pub fn to_pool_types_vector(&self) -> Vec<PoolType> {
+        let mut pool_types: Vec<PoolType> = Vec::new();
+
+        if self.include_transparent {
+            pool_types.push(PoolType::Transparent);
+        }
+
+        if self.include_sapling {
+            pool_types.push(PoolType::Sapling);
+        }
+
+        if self.include_orchard {
+            pool_types.push(PoolType::Orchard);
+        }
+
+        pool_types
+    }
+
     /// testing only
     #[allow(dead_code)]
     pub(crate) fn from_checked_parts(

--- a/zaino-proto/src/proto/utils.rs
+++ b/zaino-proto/src/proto/utils.rs
@@ -206,7 +206,7 @@ impl PoolTypeFilter {
     }
 
     /// retuns whether the filter includes transparent data
-    pub fn includes_tranparent(&self) -> bool {
+    pub fn includes_transparent(&self) -> bool {
         self.include_transparent
     }
 

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -840,7 +840,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                             height.to_string(),
                         ).await {
                             Ok(mut block) => {
-                                block = compact_block_with_pool_types(block, validated_request.pool_types());
+                                block = compact_block_with_pool_types(block, &validated_request.pool_types());
                                 if channel_tx.send(Ok(block)).await.is_err() {
                                     break;
                                 }

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -599,7 +599,7 @@ impl StateServiceSubscriber {
                                     if trim_non_nullifier {
                                         block = compact_block_to_nullifiers(block);
                                     } else {
-                                        block = compact_block_with_pool_types(block, pool_types.clone());
+                                        block = compact_block_with_pool_types(block, &pool_types);
                                     }
                                     Ok(block)
                             }
@@ -637,7 +637,7 @@ impl StateServiceSubscriber {
                                     if trim_non_nullifier {
                                         block = compact_block_to_nullifiers(block);
                                     } else {
-                                        block = compact_block_with_pool_types(block, pool_types.clone());
+                                        block = compact_block_with_pool_types(block, &pool_types);
                                     }
                                     Ok(block)
                                 }

--- a/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
+++ b/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
@@ -138,10 +138,13 @@ API / capabilities
     - Compact block contents are now filtered by PoolTypeFilter, and may include transparent transaction data (vin/vout) when selected.
 
 Migration
-- Strategy: <in-place | shadow build | rebuild>
-- Backfill: <what gets rebuilt and how broadly>
-- Completion criteria: <how we decide migration is done>
-- Failure handling: <rollback / retry behavior>
+- Strategy: In-place (metadata-only).
+- Backfill: None.
+- Completion criteria:
+  - DbMetadata.version updated from 1.0.0 to 1.1.0.
+  - DbMetadata.migration_status reset to Empty.
+- Failure handling:
+  - Idempotent: re-running re-writes the same metadata; no partial state beyond metadata.
 
 --------------------------------------------------------------------------------
 (append new entries below)

--- a/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
+++ b/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
@@ -1,0 +1,148 @@
+Zaino Finalised-State Database Changelog
+=======================================
+
+Format
+------
+One entry per database version bump (major / minor / patch). Keep entries concise and factual.
+
+Entry template:
+
+--------------------------------------------------------------------------------
+DB VERSION vX.Y.Z (from vA.B.C)
+Date: YYYY-MM-DD
+--------------------------------------------------------------------------------
+
+Summary
+- <1–3 bullets describing intent of the change>
+
+On-disk schema
+- Layout:
+  - <directory / file layout changes>
+- Tables:
+  - Added: <...>
+  - Removed: <...>
+  - Renamed: <old -> new>
+- Encoding:
+  - Keys: <what changed, if anything>
+  - Values: <what changed, if anything>
+  - Checksums / validation: <what changed, if anything>
+- Invariants:
+  - <new or changed integrity constraints>
+
+API / capabilities
+- Capability changes:
+  - Added: <...>
+  - Removed: <...>
+  - Changed: <...>
+- Public surface changes:
+  - Added: <methods / behaviors>
+  - Removed: <methods / behaviors>
+  - Changed: <semantic changes, error mapping changes>
+
+Migration
+- Strategy: <in-place | shadow build | rebuild>
+- Backfill: <what gets rebuilt and how broadly>
+- Completion criteria: <how we decide migration is done>
+- Failure handling: <rollback / retry behavior>
+
+--------------------------------------------------------------------------------
+DB VERSION v1.0.0 (from v0.0.0)
+Date: 2025-08-13
+--------------------------------------------------------------------------------
+
+Summary
+- Replace legacy v0 schema with versioned v1 schema and expanded indices / query surface.
+- Introduce stronger integrity checks and on-demand validation for v1 read paths.
+- Keep compact block retrieval available (compatibility surface).
+
+On-disk schema
+- Layout:
+  - Move to per-network version directory layout: <base>/<network>/v1/
+  - VERSION_DIRS begins at ["v1"] (new versions append, no gaps).
+- Tables:
+  - Added (v1): headers, txids, transparent, sapling, orchard, commitment_tree_data, heights (hash->height),
+    plus v1 indices for tx locations, spent outpoints, and transparent address history.
+  - Removed / superseded (v0): legacy compact-block-streamer oriented storage layout.
+- Encoding:
+  - v1 values are stored as checksum-protected `StoredEntryVar<T>` / `StoredEntryFixed<T>` entries.
+  - Canonical key bytes are used for checksum verification via `verify(key)`.
+- Invariants (v1 validation enforces):
+  - Per-table checksum verification for all per-block tables.
+  - Chain continuity: header parent hash at height h matches stored hash at h-1.
+  - Merkle consistency: header merkle root matches computed root from stored txid list.
+  - Index consistency:
+    - hash->height mapping must match the queried height.
+    - spent + addr history records must exist and match for transparent inputs/outputs.
+
+API / capabilities
+- Capability changes:
+  - v0: READ_CORE | WRITE_CORE | COMPACT_BLOCK_EXT
+  - v1: Capability::LATEST (block core/transparent/shielded, indexed block, transparent history, etc.)
+- Public surface changes:
+  - Added (v1-only; FeatureUnavailable on v0):
+    - BlockCoreExt: header/txids/range fetch, txid<->location lookup
+    - BlockTransparentExt: per-tx and per-block transparent access + ranges
+    - BlockShieldedExt: sapling/orchard per-tx and per-block access + ranges, commitment tree data (+ ranges)
+    - IndexedBlockExt: indexed block retrieval
+    - TransparentHistExt: addr records, range queries, balance/utxos, outpoint spender(s)
+  - Preserved:
+    - CompactBlockExt remains available for both v0 and v1.
+
+Migration
+- Strategy: shadow build + promotion (no in-place transformation of v0).
+- Backfill: rebuild all v1 tables/indices by ingesting chain data.
+- Completion criteria:
+  - metadata indicates migrated/ready, and required tables exist through the tip.
+  - validation succeeds for the contiguous best chain range as built.
+- Failure handling:
+  - do not promote partially built v1; continue using v0 if present; rebuild v1 on retry.
+
+--------------------------------------------------------------------------------
+DB VERSION v1.0.0 (from v1.1.0)
+Date: 2026-01-27
+--------------------------------------------------------------------------------
+
+Summary
+- Minor version bump to reflect updated compact block API contract (streaming + pool filtering semantics).
+- No schema or encoding changes; metadata-only migration updates persisted DB version marker.
+
+On-disk schema
+- Layout:
+  - No changes.
+- Tables:
+  - Added: None.
+  - Removed: None.
+  - Renamed: None.
+- Encoding:
+  - Keys: No changes.
+  - Values: No changes.
+  - Checksums / validation: No changes.
+- Invariants:
+  - No changes.
+
+API / capabilities
+- Capability changes:
+  - Added: None.
+  - Removed: None.
+  - Changed:
+    - COMPACT_BLOCK_EXT contract updated for v1 backends:
+      - get_compact_block(...) now takes a PoolTypeFilter, which selects which pool data is materialized into the returned compact block.
+      - get_compact_block_stream(...) added.
+
+- Public surface changes:
+  - Added:
+    - CompactBlockExt::get_compact_block_stream(start_height, end_height, pool_types: PoolTypeFilter).
+  - Removed: None.
+  - Changed:
+    - CompactBlockExt::get_compact_block(height, pool_types: PoolTypeFilter) signature updated.
+    - Compact block contents are now filtered by PoolTypeFilter, and may include transparent transaction data (vin/vout) when selected.
+
+Migration
+- Strategy: <in-place | shadow build | rebuild>
+- Backfill: <what gets rebuilt and how broadly>
+- Completion criteria: <how we decide migration is done>
+- Failure handling: <rollback / retry behavior>
+
+--------------------------------------------------------------------------------
+(append new entries below)
+--------------------------------------------------------------------------------

--- a/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -81,14 +81,16 @@ use crate::{
     chain_index::types::{AddrEventBytes, TransactionHash},
     error::FinalisedStateError,
     read_fixed_le, read_u32_le, read_u8, version, write_fixed_le, write_u32_le, write_u8,
-    AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, FixedEncodedLen, Height,
-    IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList,
-    StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList, ZainoVersionedSerde,
+    AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, CompactBlockStream,
+    FixedEncodedLen, Height, IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint,
+    SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList,
+    TxLocation, TxidList, ZainoVersionedSerde,
 };
 
 use async_trait::async_trait;
 use bitflags::bitflags;
 use core2::io::{self, Read, Write};
+use zaino_proto::proto::utils::PoolTypeFilter;
 
 // ***** Capability definition structs *****
 
@@ -846,12 +848,18 @@ pub trait BlockShieldedExt: Send + Sync {
 #[async_trait]
 pub trait CompactBlockExt: Send + Sync {
     /// Returns the CompactBlock for the given Height.
-    ///
-    /// TODO: Add separate range fetch method as this method is slow for fetching large ranges!
     async fn get_compact_block(
         &self,
         height: Height,
+        pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError>;
+
+    async fn get_compact_block_stream(
+        &self,
+        start_height: Height,
+        end_height: Height,
+        pool_types: PoolTypeFilter,
+    ) -> Result<CompactBlockStream, FinalisedStateError>;
 }
 
 /// `IndexedBlock` materialization extension.

--- a/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -452,7 +452,7 @@ impl DbVersion {
             }
 
             // V1: Adds chainblockv1 and transparent transaction history data.
-            (1, 0) => {
+            (1, 0) | (1, 1) => {
                 Capability::READ_CORE
                     | Capability::WRITE_CORE
                     | Capability::BLOCK_CORE_EXT

--- a/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/zaino-state/src/chain_index/finalised_state/db.rs
@@ -58,6 +58,7 @@ pub(crate) mod v1;
 
 use v0::DbV0;
 use v1::DbV1;
+use zaino_proto::proto::utils::PoolTypeFilter;
 
 use crate::{
     chain_index::{
@@ -69,9 +70,9 @@ use crate::{
     },
     config::BlockCacheConfig,
     error::FinalisedStateError,
-    AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, Height, IndexedBlock,
-    OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType,
-    TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
+    AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, CompactBlockStream, Height,
+    IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList,
+    StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
 };
 
 use async_trait::async_trait;
@@ -482,11 +483,32 @@ impl CompactBlockExt for DbBackend {
     async fn get_compact_block(
         &self,
         height: Height,
+        pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
         #[allow(unreachable_patterns)]
         match self {
-            Self::V0(db) => db.get_compact_block(height).await,
-            Self::V1(db) => db.get_compact_block(height).await,
+            Self::V0(db) => db.get_compact_block(height, pool_types).await,
+            Self::V1(db) => db.get_compact_block(height, pool_types).await,
+            _ => Err(FinalisedStateError::FeatureUnavailable("compact_block")),
+        }
+    }
+
+    async fn get_compact_block_stream(
+        &self,
+        start_height: Height,
+        end_height: Height,
+        pool_types: PoolTypeFilter,
+    ) -> Result<CompactBlockStream, FinalisedStateError> {
+        #[allow(unreachable_patterns)]
+        match self {
+            Self::V0(db) => {
+                db.get_compact_block_stream(start_height, end_height, pool_types)
+                    .await
+            }
+            Self::V1(db) => {
+                db.get_compact_block_stream(start_height, end_height, pool_types)
+                    .await
+            }
             _ => Err(FinalisedStateError::FeatureUnavailable("compact_block")),
         }
     }

--- a/zaino-state/src/chain_index/finalised_state/db/v0.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v0.rs
@@ -833,10 +833,9 @@ impl DbV0 {
 
             let block_bytes: &[u8] = txn.get(self.hashes_to_blocks, &hash_key)?;
             let block: DbCompactBlock = serde_json::from_slice(block_bytes)?;
-            // Ok(block.0)
             Ok(compact_block_with_pool_types(
                 block.0,
-                pool_types.to_pool_types_vector(),
+                &pool_types.to_pool_types_vector(),
             ))
         })
     }
@@ -944,7 +943,7 @@ impl DbV0 {
 
                     Ok(compact_block_with_pool_types(
                         db_compact_block.0,
-                        pool_types_vector.clone(),
+                        &pool_types_vector,
                     ))
                 })();
 

--- a/zaino-state/src/chain_index/finalised_state/db/v0.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v0.rs
@@ -49,11 +49,12 @@ use crate::{
     },
     config::BlockCacheConfig,
     error::FinalisedStateError,
+    local_cache::compact_block_with_pool_types,
     status::{AtomicStatus, StatusType},
-    Height, IndexedBlock,
+    CompactBlockStream, Height, IndexedBlock,
 };
 
-use zaino_proto::proto::compact_formats::CompactBlock;
+use zaino_proto::proto::{compact_formats::CompactBlock, service::PoolType, utils::PoolTypeFilter};
 
 use zebra_chain::{
     block::{Hash as ZebraHash, Height as ZebraHeight},
@@ -193,17 +194,28 @@ impl DbCore for DbV0 {
     }
 }
 
-/// `CompactBlockExt` implementation for v0.
+/// [`CompactBlockExt`] capability implementation for [`DbV0`].
 ///
-/// v0’s primary purpose is serving compact blocks (as used by lightwallet protocols).
+/// Exposes `zcash_client_backend`-compatible compact blocks derived from stored header +
+/// transaction data.
 #[async_trait]
 impl CompactBlockExt for DbV0 {
-    /// Fetches the compact block at the given height.
     async fn get_compact_block(
         &self,
         height: Height,
+        pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
-        self.get_compact_block(height).await
+        self.get_compact_block(height, pool_types).await
+    }
+
+    async fn get_compact_block_stream(
+        &self,
+        start_height: Height,
+        end_height: Height,
+        pool_types: PoolTypeFilter,
+    ) -> Result<CompactBlockStream, FinalisedStateError> {
+        self.get_compact_block_stream(start_height, end_height, pool_types)
+            .await
     }
 }
 
@@ -810,6 +822,7 @@ impl DbV0 {
     async fn get_compact_block(
         &self,
         height: crate::Height,
+        pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
         let zebra_hash =
             zebra_chain::block::Hash::from(self.get_block_hash_by_height(height).await?);
@@ -820,8 +833,156 @@ impl DbV0 {
 
             let block_bytes: &[u8] = txn.get(self.hashes_to_blocks, &hash_key)?;
             let block: DbCompactBlock = serde_json::from_slice(block_bytes)?;
-            Ok(block.0)
+            // Ok(block.0)
+            Ok(compact_block_with_pool_types(
+                block.0,
+                pool_types.to_pool_types_vector(),
+            ))
         })
+    }
+
+    /// Streams `CompactBlock` messages for an inclusive height range.
+    ///
+    /// Legacy implementation for backwards compatibility.
+    ///
+    /// Behaviour:
+    /// - The stream covers the inclusive range `[start_height, end_height]`.
+    /// - If `start_height <= end_height` the stream is ascending; otherwise it is descending.
+    /// - Blocks are fetched one-by-one by calling `get_compact_block(height, pool_types)` for
+    ///   each height in the range.
+    ///
+    /// Pool filtering:
+    /// - `pool_types` controls which per-transaction components are populated.
+    /// - Transactions that have no elements in any requested pool type are omitted from `vtx`,
+    ///   and `CompactTx.index` preserves the original transaction index within the block.
+    ///
+    /// Notes:
+    /// - This is intentionally not optimised (no LMDB cursor walk, no batch/range reads).
+    /// - Any fetch/deserialize error terminates the stream after emitting a single `tonic::Status`.
+    async fn get_compact_block_stream(
+        &self,
+        start_height: Height,
+        end_height: Height,
+        pool_types: PoolTypeFilter,
+    ) -> Result<CompactBlockStream, FinalisedStateError> {
+        let is_ascending: bool = start_height <= end_height;
+
+        let (sender, receiver) =
+            tokio::sync::mpsc::channel::<Result<CompactBlock, tonic::Status>>(128);
+
+        let env = self.env.clone();
+        let heights_to_hashes_database: lmdb::Database = self.heights_to_hashes;
+        let hashes_to_blocks_database: lmdb::Database = self.hashes_to_blocks;
+
+        let pool_types_vector: Vec<PoolType> = pool_types.to_pool_types_vector();
+
+        tokio::task::spawn_blocking(move || {
+            fn lmdb_get_status(
+                database_name: &'static str,
+                height: Height,
+                error: lmdb::Error,
+            ) -> tonic::Status {
+                match error {
+                    lmdb::Error::NotFound => tonic::Status::not_found(format!(
+                        "missing db entry in {database_name} at height {}",
+                        height.0
+                    )),
+                    other_error => tonic::Status::internal(format!(
+                        "lmdb get({database_name}) failed at height {}: {other_error}",
+                        height.0
+                    )),
+                }
+            }
+
+            let mut current_height: Height = start_height;
+
+            loop {
+                let result: Result<CompactBlock, tonic::Status> = (|| {
+                    let txn = env.begin_ro_txn().map_err(|error| {
+                        tonic::Status::internal(format!("lmdb begin_ro_txn failed: {error}"))
+                    })?;
+
+                    // height -> hash (heights_to_hashes)
+                    let zebra_height: ZebraHeight = current_height.into();
+                    let height_key: [u8; 4] = DbHeight(zebra_height).to_be_bytes();
+
+                    let hash_bytes: &[u8] = txn
+                        .get(heights_to_hashes_database, &height_key)
+                        .map_err(|error| {
+                            lmdb_get_status("heights_to_hashes", current_height, error)
+                        })?;
+
+                    let db_hash: DbHash = serde_json::from_slice(hash_bytes).map_err(|error| {
+                        tonic::Status::internal(format!(
+                            "height->hash decode failed at height {}: {error}",
+                            current_height.0
+                        ))
+                    })?;
+
+                    // hash -> block (hashes_to_blocks)
+                    let hash_key: Vec<u8> =
+                        serde_json::to_vec(&DbHash(db_hash.0)).map_err(|error| {
+                            tonic::Status::internal(format!(
+                                "hash key encode failed at height {}: {error}",
+                                current_height.0
+                            ))
+                        })?;
+
+                    let block_bytes: &[u8] = txn
+                        .get(hashes_to_blocks_database, &hash_key)
+                        .map_err(|error| {
+                            lmdb_get_status("hashes_to_blocks", current_height, error)
+                        })?;
+
+                    let db_compact_block: DbCompactBlock = serde_json::from_slice(block_bytes)
+                        .map_err(|error| {
+                            tonic::Status::internal(format!(
+                                "block decode failed at height {}: {error}",
+                                current_height.0
+                            ))
+                        })?;
+
+                    Ok(compact_block_with_pool_types(
+                        db_compact_block.0,
+                        pool_types_vector.clone(),
+                    ))
+                })();
+
+                if sender.blocking_send(result).is_err() {
+                    return;
+                }
+
+                if current_height == end_height {
+                    return;
+                }
+
+                if is_ascending {
+                    let next_value = match current_height.0.checked_add(1) {
+                        Some(value) => value,
+                        None => {
+                            let _ = sender.blocking_send(Err(tonic::Status::internal(
+                                "height overflow while iterating ascending".to_string(),
+                            )));
+                            return;
+                        }
+                    };
+                    current_height = Height(next_value);
+                } else {
+                    let next_value = match current_height.0.checked_sub(1) {
+                        Some(value) => value,
+                        None => {
+                            let _ = sender.blocking_send(Err(tonic::Status::internal(
+                                "height underflow while iterating descending".to_string(),
+                            )));
+                            return;
+                        }
+                    };
+                    current_height = Height(next_value);
+                }
+            }
+        });
+
+        Ok(CompactBlockStream::new(receiver))
     }
 }
 

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -45,6 +45,7 @@ use crate::{
     TxInCompact, TxLocation, TxOutCompact, TxidList, ZainoVersionedSerde as _,
 };
 
+use zaino_proto::proto::utils::PoolTypeFilter;
 use zebra_chain::parameters::NetworkKind;
 use zebra_state::HashOrHeight;
 
@@ -361,7 +362,8 @@ impl CompactBlockExt for DbV1 {
         &self,
         height: Height,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
-        self.get_compact_block(height).await
+        self.get_compact_block(height, PoolTypeFilter::default())
+            .await
     }
 }
 
@@ -3047,16 +3049,222 @@ impl DbV1 {
     async fn get_compact_block(
         &self,
         height: Height,
+        pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
-        let block = self.get_chain_block(height).await?;
+        let validated_height = self
+            .resolve_validated_hash_or_height(HashOrHeight::Height(height.into()))
+            .await?;
+        let height_bytes = validated_height.to_bytes()?;
 
-        match block {
-            Some(b) => Ok(b.to_compact_block()),
-            None => Err(FinalisedStateError::DataUnavailable(format!(
-                "Block {} not present in validator's state.",
-                height
-            ))),
-        }
+        tokio::task::block_in_place(|| {
+            let txn = self.env.begin_ro_txn()?;
+
+            // ----- Fetch Header -----
+            let raw = match txn.get(self.headers, &height_bytes) {
+                Ok(val) => val,
+                Err(lmdb::Error::NotFound) => {
+                    return Err(FinalisedStateError::DataUnavailable(
+                        "block data missing from db".into(),
+                    ));
+                }
+                Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+            };
+            let header: BlockHeaderData = *StoredEntryVar::from_bytes(raw)
+                .map_err(|e| FinalisedStateError::Custom(format!("header decode error: {e}")))?
+                .inner();
+
+            // ----- Fetch Txids -----
+            let raw = match txn.get(self.txids, &height_bytes) {
+                Ok(val) => val,
+                Err(lmdb::Error::NotFound) => {
+                    return Err(FinalisedStateError::DataUnavailable(
+                        "block data missing from db".into(),
+                    ));
+                }
+                Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+            };
+            let txids_stored_entry_var = StoredEntryVar::<TxidList>::from_bytes(raw)
+                .map_err(|e| FinalisedStateError::Custom(format!("txids decode error: {e}")))?;
+            let txids = txids_stored_entry_var.inner().txids();
+
+            // ----- Fetch Transparent Tx Data -----
+            let transparent_stored_entry_var = if pool_types.includes_transparent() {
+                let raw = match txn.get(self.transparent, &height_bytes) {
+                    Ok(val) => val,
+                    Err(lmdb::Error::NotFound) => {
+                        return Err(FinalisedStateError::DataUnavailable(
+                            "block data missing from db".into(),
+                        ));
+                    }
+                    Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+                };
+
+                Some(
+                    StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|e| {
+                        FinalisedStateError::Custom(format!("transparent decode error: {e}"))
+                    })?,
+                )
+            } else {
+                None
+            };
+            let transparent = match transparent_stored_entry_var.as_ref() {
+                Some(stored_entry_var) => stored_entry_var.inner().tx(),
+                None => &[],
+            };
+
+            // ----- Fetch Sapling Tx Data -----
+            let sapling_stored_entry_var = if pool_types.includes_sapling() {
+                let raw = match txn.get(self.sapling, &height_bytes) {
+                    Ok(val) => val,
+                    Err(lmdb::Error::NotFound) => {
+                        return Err(FinalisedStateError::DataUnavailable(
+                            "block data missing from db".into(),
+                        ));
+                    }
+                    Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+                };
+
+                Some(
+                    StoredEntryVar::<SaplingTxList>::from_bytes(raw).map_err(|e| {
+                        FinalisedStateError::Custom(format!("sapling decode error: {e}"))
+                    })?,
+                )
+            } else {
+                None
+            };
+            let sapling = match sapling_stored_entry_var.as_ref() {
+                Some(stored_entry_var) => stored_entry_var.inner().tx(),
+                None => &[],
+            };
+
+            // ----- Fetch Orchard Tx Data -----
+            let orchard_stored_entry_var = if pool_types.includes_orchard() {
+                let raw = match txn.get(self.orchard, &height_bytes) {
+                    Ok(val) => val,
+                    Err(lmdb::Error::NotFound) => {
+                        return Err(FinalisedStateError::DataUnavailable(
+                            "block data missing from db".into(),
+                        ));
+                    }
+                    Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+                };
+
+                Some(
+                    StoredEntryVar::<OrchardTxList>::from_bytes(raw).map_err(|e| {
+                        FinalisedStateError::Custom(format!("orchard decode error: {e}"))
+                    })?,
+                )
+            } else {
+                None
+            };
+            let orchard = match orchard_stored_entry_var.as_ref() {
+                Some(stored_entry_var) => stored_entry_var.inner().tx(),
+                None => &[],
+            };
+
+            // ----- Construct CompactTx -----
+            let vtx: Vec<zaino_proto::proto::compact_formats::CompactTx> = txids
+                .iter()
+                .enumerate()
+                .filter_map(|(i, txid)| {
+                    let spends = sapling
+                        .get(i)
+                        .and_then(|opt| opt.as_ref())
+                        .map(|s| {
+                            s.spends()
+                                .iter()
+                                .map(|sp| sp.into_compact())
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
+
+                    let outputs = sapling
+                        .get(i)
+                        .and_then(|opt| opt.as_ref())
+                        .map(|s| {
+                            s.outputs()
+                                .iter()
+                                .map(|o| o.into_compact())
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
+
+                    let actions = orchard
+                        .get(i)
+                        .and_then(|opt| opt.as_ref())
+                        .map(|o| {
+                            o.actions()
+                                .iter()
+                                .map(|a| a.into_compact())
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
+
+                    let (vin, vout) = transparent
+                        .get(i)
+                        .and_then(|opt| opt.as_ref())
+                        .map(|t| (t.compact_vin(), t.compact_vout()))
+                        .unwrap_or_default();
+
+                    // Skip txs that have no elements in any requested pool type.
+                    //
+                    // TODO: Explore whether we can avoid this check.
+                    if spends.is_empty()
+                        && outputs.is_empty()
+                        && actions.is_empty()
+                        && vin.is_empty()
+                        && vout.is_empty()
+                    {
+                        return None;
+                    }
+
+                    Some(zaino_proto::proto::compact_formats::CompactTx {
+                        index: i as u64,
+                        txid: txid.0.to_vec(),
+                        fee: 0,
+                        spends,
+                        outputs,
+                        actions,
+                        vin,
+                        vout,
+                    })
+                })
+                .collect();
+
+            // ----- Fetch Commitment Tree Data -----
+            let raw = match txn.get(self.commitment_tree_data, &height_bytes) {
+                Ok(val) => val,
+                Err(lmdb::Error::NotFound) => {
+                    return Err(FinalisedStateError::DataUnavailable(
+                        "block data missing from db".into(),
+                    ));
+                }
+                Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+            };
+            let commitment_tree_data: CommitmentTreeData = *StoredEntryFixed::from_bytes(raw)
+                .map_err(|e| {
+                    FinalisedStateError::Custom(format!("commitment_tree decode error: {e}"))
+                })?
+                .inner();
+
+            let chain_metadata = zaino_proto::proto::compact_formats::ChainMetadata {
+                sapling_commitment_tree_size: commitment_tree_data.sizes().sapling(),
+                orchard_commitment_tree_size: commitment_tree_data.sizes().orchard(),
+            };
+
+            // ----- Construct CompactBlock -----
+            Ok(zaino_proto::proto::compact_formats::CompactBlock {
+                proto_version: 4,
+                height: header.index().height().0 as u64,
+                hash: header.index().hash().0.to_vec(),
+                prev_hash: header.index().parent_hash().0.to_vec(),
+                // Is this safe?
+                time: header.data().time() as u32,
+                header: Vec::new(),
+                vtx,
+                chain_metadata: Some(chain_metadata),
+            })
+        })
     }
 
     /// Fetch database metadata.

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -39,13 +39,13 @@ use crate::{
     config::BlockCacheConfig,
     error::FinalisedStateError,
     AddrHistRecord, AddrScript, AtomicStatus, BlockHash, BlockHeaderData, CommitmentTreeData,
-    CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend, CompactSize, CompactTxData,
-    FixedEncodedLen as _, Height, IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint,
-    SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList,
-    TxInCompact, TxLocation, TxOutCompact, TxidList, ZainoVersionedSerde as _,
+    CompactBlockStream, CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend,
+    CompactSize, CompactTxData, FixedEncodedLen as _, Height, IndexedBlock, OrchardCompactTx,
+    OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx,
+    TransparentTxList, TxInCompact, TxLocation, TxOutCompact, TxidList, ZainoVersionedSerde as _,
 };
 
-use zaino_proto::proto::utils::PoolTypeFilter;
+use zaino_proto::proto::{compact_formats::CompactBlock, utils::PoolTypeFilter};
 use zebra_chain::parameters::NetworkKind;
 use zebra_state::HashOrHeight;
 
@@ -1782,11 +1782,21 @@ impl DbV1 {
     /// Fetches block headers for the given height range.
     ///
     /// Uses cursor based fetch.
+    ///
+    /// NOTE: Currently this method only fetches ranges where start_height <= end_height,
+    ///       This could be updated by following the cursor step example in
+    ///       get_compact_block_streamer.
     async fn get_block_range_headers(
         &self,
         start: Height,
         end: Height,
     ) -> Result<Vec<BlockHeaderData>, FinalisedStateError> {
+        if end.0 < start.0 {
+            return Err(FinalisedStateError::Custom(
+                "invalid block range: end < start".to_string(),
+            ));
+        }
+
         self.validate_block_range(start, end).await?;
         let start_bytes = start.to_bytes()?;
         let end_bytes = end.to_bytes()?;
@@ -1923,11 +1933,21 @@ impl DbV1 {
     /// Fetches block txids for the given height range.
     ///
     /// Uses cursor based fetch.
+    ///
+    /// NOTE: Currently this method only fetches ranges where start_height <= end_height,
+    ///       This could be updated by following the cursor step example in
+    ///       get_compact_block_streamer.
     async fn get_block_range_txids(
         &self,
         start: Height,
         end: Height,
     ) -> Result<Vec<TxidList>, FinalisedStateError> {
+        if end.0 < start.0 {
+            return Err(FinalisedStateError::Custom(
+                "invalid block range: end < start".to_string(),
+            ));
+        }
+
         self.validate_block_range(start, end).await?;
         let start_bytes = start.to_bytes()?;
         let end_bytes = end.to_bytes()?;
@@ -2082,11 +2102,21 @@ impl DbV1 {
     /// Fetches block transparent tx data for the given height range.
     ///
     /// Uses cursor based fetch.
+    ///
+    ///  NOTE: Currently this method only fetches ranges where start_height <= end_height,
+    ///       This could be updated by following the cursor step example in
+    ///       get_compact_block_streamer.
     async fn get_block_range_transparent(
         &self,
         start: Height,
         end: Height,
     ) -> Result<Vec<TransparentTxList>, FinalisedStateError> {
+        if end.0 < start.0 {
+            return Err(FinalisedStateError::Custom(
+                "invalid block range: end < start".to_string(),
+            ));
+        }
+
         self.validate_block_range(start, end).await?;
         let start_bytes = start.to_bytes()?;
         let end_bytes = end.to_bytes()?;
@@ -2243,11 +2273,21 @@ impl DbV1 {
     /// Fetches block sapling tx data for the given height range.
     ///
     /// Uses cursor based fetch.
+    ///
+    /// NOTE: Currently this method only fetches ranges where start_height <= end_height,
+    ///       This could be updated by following the cursor step example in
+    ///       get_compact_block_streamer.
     async fn get_block_range_sapling(
         &self,
         start: Height,
         end: Height,
     ) -> Result<Vec<SaplingTxList>, FinalisedStateError> {
+        if end.0 < start.0 {
+            return Err(FinalisedStateError::Custom(
+                "invalid block range: end < start".to_string(),
+            ));
+        }
+
         self.validate_block_range(start, end).await?;
         let start_bytes = start.to_bytes()?;
         let end_bytes = end.to_bytes()?;
@@ -2403,11 +2443,21 @@ impl DbV1 {
     /// Fetches block orchard tx data for the given height range.
     ///
     /// Uses cursor based fetch.
+    ///
+    /// NOTE: Currently this method only fetches ranges where start_height <= end_height,
+    ///       This could be updated by following the cursor step example in
+    ///       get_compact_block_streamer.
     async fn get_block_range_orchard(
         &self,
         start: Height,
         end: Height,
     ) -> Result<Vec<OrchardTxList>, FinalisedStateError> {
+        if end.0 < start.0 {
+            return Err(FinalisedStateError::Custom(
+                "invalid block range: end < start".to_string(),
+            ));
+        }
+
         self.validate_block_range(start, end).await?;
         let start_bytes = start.to_bytes()?;
         let end_bytes = end.to_bytes()?;
@@ -2476,11 +2526,21 @@ impl DbV1 {
     /// Fetches block commitment tree data for the given height range.
     ///
     /// Uses cursor based fetch.
+    ///
+    /// NOTE: Currently this method only fetches ranges where start_height <= end_height,
+    ///       This could be updated by following the cursor step example in
+    ///       get_compact_block_streamer.
     async fn get_block_range_commitment_tree_data(
         &self,
         start: Height,
         end: Height,
     ) -> Result<Vec<CommitmentTreeData>, FinalisedStateError> {
+        if end.0 < start.0 {
+            return Err(FinalisedStateError::Custom(
+                "invalid block range: end < start".to_string(),
+            ));
+        }
+
         self.validate_block_range(start, end).await?;
         let start_bytes = start.to_bytes()?;
         let end_bytes = end.to_bytes()?;
@@ -3044,8 +3104,6 @@ impl DbV1 {
     }
 
     /// Returns the CompactBlock for the given Height.
-    ///
-    /// TODO: Add separate range fetch method!
     async fn get_compact_block(
         &self,
         height: Height,
@@ -3206,9 +3264,18 @@ impl DbV1 {
                         .map(|t| (t.compact_vin(), t.compact_vout()))
                         .unwrap_or_default();
 
-                    // Skip txs that have no elements in any requested pool type.
+                    // Omit transactions that have no elements in any requested pool type.
                     //
-                    // TODO: Explore whether we can avoid this check.
+                    // This keeps `vtx` compact (it only contains transactions relevant to the caller’s pool filter),
+                    // but it also means:
+                    // - `vtx.len()` may be smaller than the block transaction count, and
+                    // - transaction indices in `vtx` may be non-contiguous.
+                    // Consumers must use `CompactTx.index` (the original transaction position in the block) rather
+                    // than assuming `vtx` preserves block order densely.
+                    //
+                    // TODO: Re-evaluate whether omitting "empty-for-filter" transactions is the desired API behaviour.
+                    //       Some clients may expect a position-preserving representation (one entry per txid), even if
+                    //       the per-pool fields are empty for a given filter.
                     if spends.is_empty()
                         && outputs.is_empty()
                         && actions.is_empty()
@@ -3267,6 +3334,992 @@ impl DbV1 {
         })
     }
 
+    /// Streams `CompactBlock` messages for an inclusive height range.
+    ///
+    /// This implementation is designed for high-throughput lightclient serving:
+    /// - It performs a single cursor-walk over the headers database and keeps all other databases
+    ///   (txids + optional pool-specific tx data + commitment tree data) strictly aligned to the
+    ///   same LMDB key.
+    /// - It uses *short-lived* read transactions and periodically re-seeks by key, which:
+    ///   - reduces the lifetime of LMDB reader slots,
+    ///   - bounds the amount of data held in the same read snapshot,
+    ///   - and prevents a single long stream from monopolising the environment’s read resources.
+    ///
+    /// Ordering / range semantics:
+    /// - The stream covers the inclusive range `[start_height, end_height]`.
+    /// - If `start_height <= end_height` the stream is ascending; otherwise it is descending.
+    /// - This function enforces *contiguous heights* in the headers database. Missing heights, key
+    ///   ordering problems, or cursor desynchronisation are treated as internal errors because they
+    ///   indicate database corruption or a violated storage invariant.
+    ///
+    /// Pool filtering:
+    /// - `pool_types` controls which per-transaction components are populated.
+    /// - Transactions that contain no elements in any requested pool are omitted from `vtx`.
+    ///   The original transaction index is preserved in `CompactTx.index`.
+    ///
+    /// Concurrency model:
+    /// - Spawns a dedicated blocking task (`spawn_blocking`) which performs LMDB reads and decoding.
+    /// - Results are pushed into a bounded `mpsc` channel; backpressure is applied if the consumer
+    ///   is slow.
+    ///
+    /// Errors:
+    /// - Database-missing conditions are sent downstream as `tonic::Status::not_found`.
+    /// - Decode failures, cursor desynchronisation, and invariant violations are sent as
+    ///   `tonic::Status::internal`.
+    async fn get_compact_block_stream(
+        &self,
+        start_height: Height,
+        end_height: Height,
+        pool_types: PoolTypeFilter,
+    ) -> Result<CompactBlockStream, FinalisedStateError> {
+        let (validated_start_height, validated_end_height) =
+            self.validate_block_range(start_height, end_height).await?;
+
+        let start_key_bytes = validated_start_height.to_bytes()?;
+
+        // Direction is derived from the validated heights. This relies on `validate_block_range`
+        // preserving input ordering (i.e. not normalising to (min, max)).
+        let is_ascending = validated_start_height <= validated_end_height;
+
+        // Bounded channel provides backpressure so the blocking task cannot run unbounded ahead of
+        // the gRPC consumer.
+        let (sender, receiver) =
+            tokio::sync::mpsc::channel::<Result<CompactBlock, tonic::Status>>(128);
+
+        // Clone the database environment.
+        let env = self.env.clone();
+
+        // Copy database handles into the blocking task. LMDB database handles are cheap, copyable IDs.
+        let headers_database = self.headers;
+        let txids_database = self.txids;
+        let transparent_database = self.transparent;
+        let sapling_database = self.sapling;
+        let orchard_database = self.orchard;
+        let commitment_tree_data_database = self.commitment_tree_data;
+
+        tokio::task::spawn_blocking(move || {
+            /// Maximum number of blocks to stream per LMDB read transaction.
+            ///
+            /// The cursor-walk is resumed by re-seeking to the next expected height key. This keeps
+            /// read transactions short-lived and reduces pressure on LMDB reader slots.
+            const BLOCKS_PER_READ_TRANSACTION: usize = 1024;
+
+            // =====================================================================================
+            // Helper functions
+            // =====================================================================================
+            //
+            // These helpers keep the main streaming loop readable and ensure that any failure:
+            // - emits exactly one `tonic::Status` into the stream (best-effort), and then
+            // - terminates the blocking task.
+            //
+            // They intentionally return `Option`/`Result` to allow early-exit with minimal boilerplate.
+
+            /// Send a `tonic::Status` downstream and ignore send errors.
+            ///
+            /// A send error means the receiver side has been dropped (e.g. client cancelled the RPC),
+            /// so the producer should terminate promptly.
+            fn send_status(
+                sender: &tokio::sync::mpsc::Sender<Result<CompactBlock, tonic::Status>>,
+                status: tonic::Status,
+            ) {
+                let _ = sender.blocking_send(Err(status));
+            }
+
+            /// Open a read-only cursor for `database` inside `txn`.
+            ///
+            /// On failure, emits an internal status and returns `None`.
+            fn open_ro_cursor_or_send<'txn>(
+                sender: &tokio::sync::mpsc::Sender<Result<CompactBlock, tonic::Status>>,
+                txn: &'txn lmdb::RoTransaction<'txn>,
+                database: lmdb::Database,
+                database_name: &'static str,
+            ) -> Option<lmdb::RoCursor<'txn>> {
+                match txn.open_ro_cursor(database) {
+                    Ok(cursor) => Some(cursor),
+                    Err(error) => {
+                        send_status(
+                            sender,
+                            tonic::Status::internal(format!(
+                                "lmdb open_ro_cursor({database_name}) failed: {error}"
+                            )),
+                        );
+                        None
+                    }
+                }
+            }
+
+            /// Position `cursor` exactly at `requested_key` using `MDB_SET_KEY`.
+            ///
+            /// Returns the `(key, value)` pair at that key. The returned `key` is expected to equal
+            /// `requested_key` (the function enforces this).
+            ///
+            /// Some LMDB bindings occasionally return `Ok((None, value))` for cursor operations. When
+            /// that happens:
+            /// - If `verify_on_none_key` is true, we call `MDB_GET_CURRENT` once to recover and verify
+            ///   the current key.
+            /// - Otherwise we assume the cursor is correctly positioned and return `(requested_key, value)`.
+            ///
+            /// On `NotFound`, emits `not_found_status`. On other failures or verification failure, emits
+            /// `internal(...)`. In all error cases it returns `None`.
+            fn cursor_set_key_or_send<'txn>(
+                sender: &tokio::sync::mpsc::Sender<Result<CompactBlock, tonic::Status>>,
+                cursor: &lmdb::RoCursor<'txn>,
+                requested_key: &'txn [u8],
+                cursor_name: &'static str,
+                not_found_status: tonic::Status,
+                verify_on_none_key: bool,
+            ) -> Option<(&'txn [u8], &'txn [u8])> {
+                match cursor.get(Some(requested_key), None, lmdb_sys::MDB_SET_KEY) {
+                    Ok((Some(found_key), found_val)) => {
+                        if found_key != requested_key {
+                            send_status(
+                                sender,
+                                tonic::Status::internal(format!(
+                                    "lmdb SET_KEY({cursor_name}) returned non-matching key"
+                                )),
+                            );
+                            None
+                        } else {
+                            Some((found_key, found_val))
+                        }
+                    }
+                    Ok((None, found_val)) => {
+                        // Some builds / bindings can return None for the key for certain ops. If requested,
+                        // verify the cursor actually landed on the requested key via GET_CURRENT.
+                        if verify_on_none_key {
+                            let (recovered_key_opt, recovered_val) =
+                                match cursor.get(None, None, lmdb_sys::MDB_GET_CURRENT) {
+                                    Ok(pair) => pair,
+                                    Err(error) => {
+                                        send_status(
+                                            sender,
+                                            tonic::Status::internal(format!(
+                                            "lmdb cursor GET_CURRENT({cursor_name}) failed: {error}"
+                                        )),
+                                        );
+                                        return None;
+                                    }
+                                };
+
+                            let recovered_key = match recovered_key_opt {
+                                Some(key) => key,
+                                None => {
+                                    send_status(
+                                        sender,
+                                        tonic::Status::internal(format!(
+                                            "lmdb GET_CURRENT({cursor_name}) returned no key"
+                                        )),
+                                    );
+                                    return None;
+                                }
+                            };
+
+                            if recovered_key != requested_key {
+                                send_status(
+                                sender,
+                                tonic::Status::internal(format!(
+                                    "lmdb SET_KEY({cursor_name}) landed on unexpected key: expected {:?}, got {:?}",
+                                    requested_key,
+                                    recovered_key,
+                                )),
+                            );
+                                return None;
+                            }
+
+                            Some((recovered_key, recovered_val))
+                        } else {
+                            // Assume SET_KEY success implies match; return the requested key + value.
+                            Some((requested_key, found_val))
+                        }
+                    }
+                    Err(lmdb::Error::NotFound) => {
+                        send_status(sender, not_found_status);
+                        None
+                    }
+                    Err(error) => {
+                        send_status(
+                            sender,
+                            tonic::Status::internal(format!(
+                                "lmdb cursor SET_KEY({cursor_name}) failed: {error}"
+                            )),
+                        );
+                        None
+                    }
+                }
+            }
+
+            /// Step the headers cursor using `step_op` and return the next `(key, value)` pair.
+            ///
+            /// This is special-cased because the headers cursor is the *driving cursor*; all other
+            /// cursors must remain aligned to whatever key the headers cursor moves to.
+            ///
+            /// Returns:
+            /// - `Ok(Some((k, v)))` when the cursor moved successfully.
+            /// - `Ok(None)` when the cursor reached the end (`NotFound`).
+            /// - `Err(())` when an error status has been emitted and streaming must stop.
+            #[allow(clippy::complexity)]
+            fn headers_step_or_send<'txn>(
+                sender: &tokio::sync::mpsc::Sender<Result<CompactBlock, tonic::Status>>,
+                headers_cursor: &lmdb::RoCursor<'txn>,
+                step_op: lmdb_sys::MDB_cursor_op,
+            ) -> Result<Option<(&'txn [u8], &'txn [u8])>, ()> {
+                match headers_cursor.get(None, None, step_op) {
+                    Ok((Some(found_key), found_val)) => Ok(Some((found_key, found_val))),
+                    Ok((None, _found_val)) => {
+                        // Some bindings can return None for the key; recover via GET_CURRENT.
+                        let (recovered_key_opt, recovered_val) =
+                            match headers_cursor.get(None, None, lmdb_sys::MDB_GET_CURRENT) {
+                                Ok(pair) => pair,
+                                Err(error) => {
+                                    send_status(
+                                        sender,
+                                        tonic::Status::internal(format!(
+                                            "lmdb cursor GET_CURRENT(headers) failed: {error}"
+                                        )),
+                                    );
+                                    return Err(());
+                                }
+                            };
+                        let recovered_key = match recovered_key_opt {
+                            Some(key) => key,
+                            None => {
+                                send_status(
+                                    sender,
+                                    tonic::Status::internal(
+                                        "lmdb GET_CURRENT(headers) returned no key".to_string(),
+                                    ),
+                                );
+                                return Err(());
+                            }
+                        };
+                        Ok(Some((recovered_key, recovered_val)))
+                    }
+                    Err(lmdb::Error::NotFound) => Ok(None),
+                    Err(error) => {
+                        send_status(
+                            sender,
+                            tonic::Status::internal(format!(
+                                "lmdb cursor step(headers) failed: {error}"
+                            )),
+                        );
+                        Err(())
+                    }
+                }
+            }
+
+            /// Step a non-header cursor and enforce that it remains aligned to `expected_key`.
+            ///
+            /// The design invariant for this streamer is:
+            /// - the headers cursor chooses the next key
+            /// - every other cursor must produce a value at that *same* key (otherwise the per-height
+            ///   databases are inconsistent or a cursor has desynchronised).
+            ///
+            /// Returns the value slice for `expected_key` on success.
+            /// On `NotFound`, emits `not_found_status`.
+            /// On key mismatch or other errors, emits an internal error.
+            fn cursor_step_expect_key_or_send<'txn>(
+                sender: &tokio::sync::mpsc::Sender<Result<CompactBlock, tonic::Status>>,
+                cursor: &lmdb::RoCursor<'txn>,
+                step_op: lmdb_sys::MDB_cursor_op,
+                expected_key: &[u8],
+                cursor_name: &'static str,
+                not_found_status: tonic::Status,
+            ) -> Option<&'txn [u8]> {
+                match cursor.get(None, None, step_op) {
+                    Ok((Some(found_key), found_val)) => {
+                        if found_key != expected_key {
+                            send_status(
+                                sender,
+                                tonic::Status::internal(format!(
+                                "lmdb cursor desync({cursor_name}): expected key {:?}, got {:?}",
+                                expected_key, found_key
+                            )),
+                            );
+                            None
+                        } else {
+                            Some(found_val)
+                        }
+                    }
+                    Ok((None, _found_val)) => {
+                        // Some bindings can return None for the key; recover via GET_CURRENT.
+                        let (recovered_key_opt, recovered_val) =
+                            match cursor.get(None, None, lmdb_sys::MDB_GET_CURRENT) {
+                                Ok(pair) => pair,
+                                Err(error) => {
+                                    send_status(
+                                        sender,
+                                        tonic::Status::internal(format!(
+                                        "lmdb cursor GET_CURRENT({cursor_name}) failed: {error}"
+                                    )),
+                                    );
+                                    return None;
+                                }
+                            };
+
+                        let recovered_key = match recovered_key_opt {
+                            Some(key) => key,
+                            None => {
+                                send_status(
+                                    sender,
+                                    tonic::Status::internal(format!(
+                                        "lmdb GET_CURRENT({cursor_name}) returned no key"
+                                    )),
+                                );
+                                return None;
+                            }
+                        };
+
+                        if recovered_key != expected_key {
+                            send_status(
+                                sender,
+                                tonic::Status::internal(format!(
+                                "lmdb cursor desync({cursor_name}): expected key {:?}, got {:?}",
+                                expected_key, recovered_key
+                            )),
+                            );
+                            None
+                        } else {
+                            Some(recovered_val)
+                        }
+                    }
+                    Err(lmdb::Error::NotFound) => {
+                        send_status(sender, not_found_status);
+                        None
+                    }
+                    Err(error) => {
+                        send_status(
+                            sender,
+                            tonic::Status::internal(format!(
+                                "lmdb cursor step({cursor_name}) failed: {error}"
+                            )),
+                        );
+                        None
+                    }
+                }
+            }
+
+            // =====================================================================================
+            // Blocking streaming loop
+            // =====================================================================================
+
+            let step_op = if is_ascending {
+                lmdb_sys::MDB_NEXT
+            } else {
+                lmdb_sys::MDB_PREV
+            };
+
+            // Contiguous-height enforcement: we expect every emitted block to have exactly this height.
+            // This catches missing heights and cursor ordering/key-encoding problems early.
+            let mut expected_height = validated_start_height;
+
+            // Key used to re-seek at the start of each transaction chunk.
+            // This begins at the start height and advances by exactly one height per emitted block.
+            let mut next_start_key_bytes: Vec<u8> = start_key_bytes;
+
+            loop {
+                // Stop once we have emitted the inclusive end height.
+                if is_ascending {
+                    if expected_height > validated_end_height {
+                        return;
+                    }
+                } else if expected_height < validated_end_height {
+                    return;
+                }
+
+                // Open a short-lived read transaction for this chunk.
+                //
+                // We intentionally drop the transaction regularly to keep reader slots available and
+                // to avoid holding a single snapshot for very large streams.
+                let txn = match env.begin_ro_txn() {
+                    Ok(txn) => txn,
+                    Err(error) => {
+                        send_status(
+                            &sender,
+                            tonic::Status::internal(format!("lmdb begin_ro_txn failed: {error}")),
+                        );
+                        return;
+                    }
+                };
+
+                // Open cursors. Headers is the driving cursor; all others must remain key-aligned.
+                let headers_cursor =
+                    match open_ro_cursor_or_send(&sender, &txn, headers_database, "headers") {
+                        Some(cursor) => cursor,
+                        None => return,
+                    };
+
+                let txids_cursor =
+                    match open_ro_cursor_or_send(&sender, &txn, txids_database, "txids") {
+                        Some(cursor) => cursor,
+                        None => return,
+                    };
+
+                let transparent_cursor = if pool_types.includes_transparent() {
+                    match open_ro_cursor_or_send(&sender, &txn, transparent_database, "transparent")
+                    {
+                        Some(cursor) => Some(cursor),
+                        None => return,
+                    }
+                } else {
+                    None
+                };
+
+                let sapling_cursor = if pool_types.includes_sapling() {
+                    match open_ro_cursor_or_send(&sender, &txn, sapling_database, "sapling") {
+                        Some(cursor) => Some(cursor),
+                        None => return,
+                    }
+                } else {
+                    None
+                };
+
+                let orchard_cursor = if pool_types.includes_orchard() {
+                    match open_ro_cursor_or_send(&sender, &txn, orchard_database, "orchard") {
+                        Some(cursor) => Some(cursor),
+                        None => return,
+                    }
+                } else {
+                    None
+                };
+
+                let commitment_tree_cursor = match open_ro_cursor_or_send(
+                    &sender,
+                    &txn,
+                    commitment_tree_data_database,
+                    "commitment_tree_data",
+                ) {
+                    Some(cursor) => cursor,
+                    None => return,
+                };
+
+                // Position headers cursor at the start key for this chunk. This is the authoritative key
+                // that all other cursors must align to.
+                let (current_key, mut raw_header_bytes) = match cursor_set_key_or_send(
+                    &sender,
+                    &headers_cursor,
+                    next_start_key_bytes.as_slice(),
+                    "headers",
+                    tonic::Status::not_found(format!(
+                        "missing header at requested start height key {:?}",
+                        next_start_key_bytes
+                    )),
+                    true, // verify-on-none-key
+                ) {
+                    Some(pair) => pair,
+                    None => return,
+                };
+
+                // Align all other cursors to the exact same key.
+                let (_txids_key, mut raw_txids_bytes) = match cursor_set_key_or_send(
+                    &sender,
+                    &txids_cursor,
+                    current_key,
+                    "txids",
+                    tonic::Status::not_found("block data missing from db (txids)"),
+                    true,
+                ) {
+                    Some(pair) => pair,
+                    None => return,
+                };
+
+                let mut raw_transparent_bytes: Option<&[u8]> =
+                    if let Some(cursor) = transparent_cursor.as_ref() {
+                        let (_key, val) = match cursor_set_key_or_send(
+                            &sender,
+                            cursor,
+                            current_key,
+                            "transparent",
+                            tonic::Status::not_found("block data missing from db (transparent)"),
+                            true,
+                        ) {
+                            Some(pair) => pair,
+                            None => return,
+                        };
+                        Some(val)
+                    } else {
+                        None
+                    };
+
+                let mut raw_sapling_bytes: Option<&[u8]> =
+                    if let Some(cursor) = sapling_cursor.as_ref() {
+                        let (_key, val) = match cursor_set_key_or_send(
+                            &sender,
+                            cursor,
+                            current_key,
+                            "sapling",
+                            tonic::Status::not_found("block data missing from db (sapling)"),
+                            true,
+                        ) {
+                            Some(pair) => pair,
+                            None => return,
+                        };
+                        Some(val)
+                    } else {
+                        None
+                    };
+
+                let mut raw_orchard_bytes: Option<&[u8]> =
+                    if let Some(cursor) = orchard_cursor.as_ref() {
+                        let (_key, val) = match cursor_set_key_or_send(
+                            &sender,
+                            cursor,
+                            current_key,
+                            "orchard",
+                            tonic::Status::not_found("block data missing from db (orchard)"),
+                            true,
+                        ) {
+                            Some(pair) => pair,
+                            None => return,
+                        };
+                        Some(val)
+                    } else {
+                        None
+                    };
+
+                let (_commitment_key, mut raw_commitment_tree_bytes) = match cursor_set_key_or_send(
+                    &sender,
+                    &commitment_tree_cursor,
+                    current_key,
+                    "commitment_tree_data",
+                    tonic::Status::not_found("block data missing from db (commitment_tree_data)"),
+                    true,
+                ) {
+                    Some(pair) => pair,
+                    None => return,
+                };
+
+                let mut blocks_streamed_in_transaction: usize = 0;
+
+                loop {
+                    // ----- Decode and validate block header -----
+                    let header: BlockHeaderData = match StoredEntryVar::from_bytes(raw_header_bytes)
+                        .map_err(|error| format!("header decode error: {error}"))
+                    {
+                        Ok(entry) => *entry.inner(),
+                        Err(message) => {
+                            send_status(&sender, tonic::Status::internal(message));
+                            return;
+                        }
+                    };
+
+                    // Contiguous-height check: ensures cursor ordering and storage invariants are intact.
+                    let current_height = header.index().height();
+                    if current_height != expected_height {
+                        send_status(
+                            &sender,
+                            tonic::Status::internal(format!(
+                                "missing height or out-of-order headers: expected {}, got {}",
+                                expected_height.0, current_height.0
+                            )),
+                        );
+                        return;
+                    }
+
+                    // ----- Decode txids and optional pool data -----
+                    let txids_stored_entry_var =
+                        match StoredEntryVar::<TxidList>::from_bytes(raw_txids_bytes)
+                            .map_err(|error| format!("txids decode error: {error}"))
+                        {
+                            Ok(entry) => entry,
+                            Err(message) => {
+                                send_status(&sender, tonic::Status::internal(message));
+                                return;
+                            }
+                        };
+                    let txids = txids_stored_entry_var.inner().txids();
+
+                    // Each pool database stores a per-height vector aligned to the txids list:
+                    // one entry per transaction index (typically `Option<T>` per tx).
+                    let transparent_entries: Option<StoredEntryVar<TransparentTxList>> =
+                        if let Some(raw) = raw_transparent_bytes {
+                            match StoredEntryVar::<TransparentTxList>::from_bytes(raw)
+                                .map_err(|error| format!("transparent decode error: {error}"))
+                            {
+                                Ok(entry) => Some(entry),
+                                Err(message) => {
+                                    send_status(&sender, tonic::Status::internal(message));
+                                    return;
+                                }
+                            }
+                        } else {
+                            None
+                        };
+
+                    let sapling_entries: Option<StoredEntryVar<SaplingTxList>> =
+                        if let Some(raw) = raw_sapling_bytes {
+                            match StoredEntryVar::<SaplingTxList>::from_bytes(raw)
+                                .map_err(|error| format!("sapling decode error: {error}"))
+                            {
+                                Ok(entry) => Some(entry),
+                                Err(message) => {
+                                    send_status(&sender, tonic::Status::internal(message));
+                                    return;
+                                }
+                            }
+                        } else {
+                            None
+                        };
+
+                    let orchard_entries: Option<StoredEntryVar<OrchardTxList>> =
+                        if let Some(raw) = raw_orchard_bytes {
+                            match StoredEntryVar::<OrchardTxList>::from_bytes(raw)
+                                .map_err(|error| format!("orchard decode error: {error}"))
+                            {
+                                Ok(entry) => Some(entry),
+                                Err(message) => {
+                                    send_status(&sender, tonic::Status::internal(message));
+                                    return;
+                                }
+                            }
+                        } else {
+                            None
+                        };
+
+                    let transparent = match transparent_entries.as_ref() {
+                        Some(entry) => entry.inner().tx(),
+                        None => &[],
+                    };
+                    let sapling = match sapling_entries.as_ref() {
+                        Some(entry) => entry.inner().tx(),
+                        None => &[],
+                    };
+                    let orchard = match orchard_entries.as_ref() {
+                        Some(entry) => entry.inner().tx(),
+                        None => &[],
+                    };
+
+                    // Invariant: if a pool is requested, its per-height vector length must match txids.
+                    if pool_types.includes_transparent() && transparent.len() != txids.len() {
+                        send_status(
+                        &sender,
+                        tonic::Status::internal(format!(
+                            "transparent list length mismatch at height {}: txids={}, transparent={}",
+                            current_height.0,
+                            txids.len(),
+                            transparent.len(),
+                        )),
+                    );
+                        return;
+                    }
+                    if pool_types.includes_sapling() && sapling.len() != txids.len() {
+                        send_status(
+                            &sender,
+                            tonic::Status::internal(format!(
+                                "sapling list length mismatch at height {}: txids={}, sapling={}",
+                                current_height.0,
+                                txids.len(),
+                                sapling.len(),
+                            )),
+                        );
+                        return;
+                    }
+                    if pool_types.includes_orchard() && orchard.len() != txids.len() {
+                        send_status(
+                            &sender,
+                            tonic::Status::internal(format!(
+                                "orchard list length mismatch at height {}: txids={}, orchard={}",
+                                current_height.0,
+                                txids.len(),
+                                orchard.len(),
+                            )),
+                        );
+                        return;
+                    }
+
+                    // ----- Build CompactTx list -----
+                    //
+                    // `CompactTx.index` is the original transaction index within the block.
+                    // This implementation omits transactions that contain no elements in any requested pool type,
+                    // which means:
+                    // - `vtx.len()` may be smaller than the number of txids in the block, and
+                    // - indices in `vtx` may be non-contiguous.
+                    // Consumers must interpret `CompactTx.index` as authoritative.
+                    //
+                    // TODO: Re-evaluate whether omitting "empty-for-filter" transactions is the desired API behaviour.
+                    //       Some clients may expect a position-preserving representation (one entry per txid), even if
+                    //       the per-pool fields are empty for a given filter.
+                    let mut vtx: Vec<zaino_proto::proto::compact_formats::CompactTx> =
+                        Vec::with_capacity(txids.len());
+
+                    for (i, txid) in txids.iter().enumerate() {
+                        let spends = sapling
+                            .get(i)
+                            .and_then(|opt| opt.as_ref())
+                            .map(|s| {
+                                s.spends()
+                                    .iter()
+                                    .map(|sp| sp.into_compact())
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
+
+                        let outputs = sapling
+                            .get(i)
+                            .and_then(|opt| opt.as_ref())
+                            .map(|s| {
+                                s.outputs()
+                                    .iter()
+                                    .map(|o| o.into_compact())
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
+
+                        let actions = orchard
+                            .get(i)
+                            .and_then(|opt| opt.as_ref())
+                            .map(|o| {
+                                o.actions()
+                                    .iter()
+                                    .map(|a| a.into_compact())
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
+
+                        let (vin, vout) = transparent
+                            .get(i)
+                            .and_then(|opt| opt.as_ref())
+                            .map(|t| (t.compact_vin(), t.compact_vout()))
+                            .unwrap_or_default();
+
+                        // Omit transactions that have no elements in any requested pool type.
+                        //
+                        // Note that omission produces a sparse `vtx` (by original transaction index). Clients must use
+                        // `CompactTx.index` rather than assuming contiguous ordering.
+                        //
+                        // TODO: Re-evaluate whether omission is the desired API behaviour for all consumers.
+                        if spends.is_empty()
+                            && outputs.is_empty()
+                            && actions.is_empty()
+                            && vin.is_empty()
+                            && vout.is_empty()
+                        {
+                            continue;
+                        }
+
+                        vtx.push(zaino_proto::proto::compact_formats::CompactTx {
+                            index: i as u64,
+                            txid: txid.0.to_vec(),
+                            fee: 0,
+                            spends,
+                            outputs,
+                            actions,
+                            vin,
+                            vout,
+                        });
+                    }
+
+                    // ----- Decode commitment tree data and construct block -----
+                    let commitment_tree_data: CommitmentTreeData =
+                        match StoredEntryFixed::from_bytes(raw_commitment_tree_bytes)
+                            .map_err(|error| format!("commitment_tree decode error: {error}"))
+                        {
+                            Ok(entry) => *entry.inner(),
+                            Err(message) => {
+                                send_status(&sender, tonic::Status::internal(message));
+                                return;
+                            }
+                        };
+
+                    let chain_metadata = zaino_proto::proto::compact_formats::ChainMetadata {
+                        sapling_commitment_tree_size: commitment_tree_data.sizes().sapling(),
+                        orchard_commitment_tree_size: commitment_tree_data.sizes().orchard(),
+                    };
+
+                    let compact_block = zaino_proto::proto::compact_formats::CompactBlock {
+                        proto_version: 4,
+                        height: header.index().height().0 as u64,
+                        hash: header.index().hash().0.to_vec(),
+                        prev_hash: header.index().parent_hash().0.to_vec(),
+                        // NOTE: `time()` is stored in the DB as a wider integer; this cast assumes it is
+                        // always representable in `u32` for the protobuf.
+                        time: header.data().time() as u32,
+                        header: Vec::new(),
+                        vtx,
+                        chain_metadata: Some(chain_metadata),
+                    };
+
+                    // Send the block downstream; if the receiver is gone, stop immediately.
+                    if sender.blocking_send(Ok(compact_block)).is_err() {
+                        return;
+                    }
+
+                    // If we just emitted the inclusive end height, stop without stepping cursors further.
+                    if current_height == validated_end_height {
+                        return;
+                    }
+
+                    blocks_streamed_in_transaction += 1;
+
+                    // Compute the next expected height (used both for contiguity checking and chunk re-seek).
+                    let next_expected_height = if is_ascending {
+                        match expected_height.0.checked_add(1) {
+                            Some(value) => Height(value),
+                            None => {
+                                send_status(
+                                    &sender,
+                                    tonic::Status::internal(
+                                        "expected_height overflow while iterating ascending"
+                                            .to_string(),
+                                    ),
+                                );
+                                return;
+                            }
+                        }
+                    } else {
+                        match expected_height.0.checked_sub(1) {
+                            Some(value) => Height(value),
+                            None => {
+                                send_status(
+                                    &sender,
+                                    tonic::Status::internal(
+                                        "expected_height underflow while iterating descending"
+                                            .to_string(),
+                                    ),
+                                );
+                                return;
+                            }
+                        }
+                    };
+
+                    // Chunk boundary: drop the current read transaction after N blocks and re-seek in a new
+                    // transaction on the next loop iteration. This avoids a single long-lived snapshot.
+                    if blocks_streamed_in_transaction >= BLOCKS_PER_READ_TRANSACTION {
+                        match next_expected_height.to_bytes() {
+                            Ok(bytes) => {
+                                next_start_key_bytes = bytes;
+                                expected_height = next_expected_height;
+                                break;
+                            }
+                            Err(error) => {
+                                send_status(
+                                    &sender,
+                                    tonic::Status::internal(format!(
+                                        "height to_bytes failed at chunk boundary: {error}"
+                                    )),
+                                );
+                                return;
+                            }
+                        }
+                    }
+
+                    // Advance all cursors in lockstep. Headers drives the next key; all others must match it.
+                    let next_headers = match headers_step_or_send(&sender, &headers_cursor, step_op)
+                    {
+                        Ok(value) => value,
+                        Err(()) => return,
+                    };
+
+                    let (next_key, next_header_val) = match next_headers {
+                        Some(pair) => pair,
+                        None => {
+                            // Headers ended early; if we have not reached the requested end height, the
+                            // database no longer satisfies the contiguous-height invariant for this range.
+                            if current_height != validated_end_height {
+                                send_status(
+                                    &sender,
+                                    tonic::Status::internal(format!(
+                                    "headers cursor ended early at height {}; expected to reach {}",
+                                    current_height.0, validated_end_height.0
+                                )),
+                                );
+                            }
+                            return;
+                        }
+                    };
+
+                    let next_txids_val = match cursor_step_expect_key_or_send(
+                        &sender,
+                        &txids_cursor,
+                        step_op,
+                        next_key,
+                        "txids",
+                        tonic::Status::not_found("block data missing from db (txids)"),
+                    ) {
+                        Some(val) => val,
+                        None => return,
+                    };
+
+                    let next_transparent_val: Option<&[u8]> = if let Some(cursor) =
+                        transparent_cursor.as_ref()
+                    {
+                        match cursor_step_expect_key_or_send(
+                            &sender,
+                            cursor,
+                            step_op,
+                            next_key,
+                            "transparent",
+                            tonic::Status::not_found("block data missing from db (transparent)"),
+                        ) {
+                            Some(val) => Some(val),
+                            None => return,
+                        }
+                    } else {
+                        None
+                    };
+
+                    let next_sapling_val: Option<&[u8]> =
+                        if let Some(cursor) = sapling_cursor.as_ref() {
+                            match cursor_step_expect_key_or_send(
+                                &sender,
+                                cursor,
+                                step_op,
+                                next_key,
+                                "sapling",
+                                tonic::Status::not_found("block data missing from db (sapling)"),
+                            ) {
+                                Some(val) => Some(val),
+                                None => return,
+                            }
+                        } else {
+                            None
+                        };
+
+                    let next_orchard_val: Option<&[u8]> =
+                        if let Some(cursor) = orchard_cursor.as_ref() {
+                            match cursor_step_expect_key_or_send(
+                                &sender,
+                                cursor,
+                                step_op,
+                                next_key,
+                                "orchard",
+                                tonic::Status::not_found("block data missing from db (orchard)"),
+                            ) {
+                                Some(val) => Some(val),
+                                None => return,
+                            }
+                        } else {
+                            None
+                        };
+
+                    let next_commitment_tree_val = match cursor_step_expect_key_or_send(
+                        &sender,
+                        &commitment_tree_cursor,
+                        step_op,
+                        next_key,
+                        "commitment_tree_data",
+                        tonic::Status::not_found(
+                            "block data missing from db (commitment_tree_data)",
+                        ),
+                    ) {
+                        Some(val) => val,
+                        None => return,
+                    };
+
+                    raw_header_bytes = next_header_val;
+                    raw_txids_bytes = next_txids_val;
+                    raw_transparent_bytes = next_transparent_val;
+                    raw_sapling_bytes = next_sapling_val;
+                    raw_orchard_bytes = next_orchard_val;
+                    raw_commitment_tree_bytes = next_commitment_tree_val;
+
+                    expected_height = next_expected_height;
+                }
+            }
+        });
+
+        Ok(CompactBlockStream::new(receiver))
+    }
+
     /// Fetch database metadata.
     async fn get_metadata(&self) -> Result<DbMetadata, FinalisedStateError> {
         tokio::task::block_in_place(|| {
@@ -3308,7 +4361,7 @@ impl DbV1 {
     // - Validation here is *structural / integrity* validation of stored records plus basic chain
     //   continuity checks (parent hash, header merkle root vs txids).
     // - It is intentionally “lightweight” and does **not** attempt full consensus verification.
-    // - NOTE: It is planned to add basic shielded tx data validation using the "block_commitments"
+    // - NOTE / TODO: It is planned to add basic shielded tx data validation using the "block_commitments"
     //   field in [`BlockData`] however this is currently unimplemented.
 
     /// Return `true` if `height` is already known-good.
@@ -3731,8 +4784,10 @@ impl DbV1 {
     /// `validated_set`.
     ///
     /// Semantics:
-    /// - If `end < start`, returns an error.
-    /// - If the entire range is already validated, returns `(start, end)` without touching LMDB.
+    /// - Accepts either ordering of `start` and `end`.
+    /// - Validates the inclusive set `{min(start,end) ..= max(start,end)}` in ascending order.
+    /// - If the entire normalized range is already validated, returns `(start, end)` without
+    ///   touching LMDB (preserves the caller's original ordering).
     /// - Otherwise, validates each missing height in ascending order using `validate_block_blocking`.
     ///
     /// WARNING:
@@ -3744,21 +4799,22 @@ impl DbV1 {
         start: Height,
         end: Height,
     ) -> Result<(Height, Height), FinalisedStateError> {
-        if end.0 < start.0 {
-            return Err(FinalisedStateError::Custom(
-                "invalid block range: end < start".to_string(),
-            ));
-        }
+        // Normalize the range for validation, but preserve `(start, end)` ordering in the return.
+        let (range_start, range_end) = if start.0 <= end.0 {
+            (start, end)
+        } else {
+            (end, start)
+        };
 
         let tip = self.validated_tip.load(Ordering::Acquire);
-        let mut h = std::cmp::max(start.0, tip);
+        let mut h = std::cmp::max(range_start.0, tip);
 
-        if h > end.0 {
+        if h > range_end.0 {
             return Ok((start, end));
         }
 
         tokio::task::block_in_place(|| {
-            while h <= end.0 {
+            while h <= range_end.0 {
                 if self.is_validated(h) {
                     h += 1;
                     continue;
@@ -3766,19 +4822,16 @@ impl DbV1 {
 
                 let height = Height(h);
                 let height_bytes = height.to_bytes()?;
-                let bytes = {
-                    let ro = self.env.begin_ro_txn()?;
-                    let bytes = ro.get(self.headers, &height_bytes).map_err(|e| {
-                        if e == lmdb::Error::NotFound {
-                            FinalisedStateError::Custom("height not found in best chain".into())
-                        } else {
-                            FinalisedStateError::LmdbError(e)
-                        }
-                    })?;
-                    bytes.to_vec()
-                };
+                let ro = self.env.begin_ro_txn()?;
+                let bytes = ro.get(self.headers, &height_bytes).map_err(|e| {
+                    if e == lmdb::Error::NotFound {
+                        FinalisedStateError::Custom("height not found in best chain".into())
+                    } else {
+                        FinalisedStateError::LmdbError(e)
+                    }
+                })?;
 
-                let hash = *StoredEntryVar::<BlockHeaderData>::deserialize(&*bytes)?
+                let hash = *StoredEntryVar::<BlockHeaderData>::deserialize(bytes)?
                     .inner()
                     .index()
                     .hash();

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -361,8 +361,18 @@ impl CompactBlockExt for DbV1 {
     async fn get_compact_block(
         &self,
         height: Height,
+        pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
-        self.get_compact_block(height, PoolTypeFilter::default())
+        self.get_compact_block(height, pool_types).await
+    }
+
+    async fn get_compact_block_stream(
+        &self,
+        start_height: Height,
+        end_height: Height,
+        pool_types: PoolTypeFilter,
+    ) -> Result<CompactBlockStream, FinalisedStateError> {
+        self.get_compact_block_stream(start_height, end_height, pool_types)
             .await
     }
 }

--- a/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -19,6 +19,10 @@
 //!   - holds the router, config, current and target versions, and a `BlockchainSource`,
 //!   - repeatedly selects and runs the next migration via `get_migration()`.
 //!
+//! - [`MigrationStep`]:
+//!   - enum-based dispatch wrapper used by `MigrationManager` to select between multiple concrete
+//!     `Migration<T>` implementations (Rust cannot return different `impl Trait` types from a `match`).
+//!
 //! - [`capability::MigrationStatus`]:
 //!   - stored in `DbMetadata` and used to resume work safely after shutdown.
 //!
@@ -62,10 +66,24 @@
 //! - Promote shadow to primary via `router.promote_shadow()`.
 //! - Delete the old v0 directory asynchronously once all strong references are dropped.
 //!
+//! ## v1.0.0 → v1.1.0
+//!
+//! `Migration1_0_0To1_1_0` is a **minor version bump** with **no schema changes**, but does include
+//! changes to the external ZainoDB API.
+//!
+//! It updates the stored `DbMetadata` version to reflect the v1.1.0 API contract:
+//! - `CompactBlockExt` now includes `get_compact_block_stream(...)`.
+//! - compact block transaction materialization is now selected via `PoolTypeFilter` (including
+//!   optional transparent data).
+//!
+//! This release also introduces [`MigrationStep`], the enum-based migration dispatcher used by
+//! [`MigrationManager`], to allow selecting between multiple concrete migration implementations.
+//!
 //! # Development: adding a new migration step
 //!
 //! 1. Introduce a new `struct MigrationX_Y_ZToA_B_C;` and implement `Migration<T>`.
-//! 2. Register it in `MigrationManager::get_migration()` by matching on the *current* version.
+//! 2. Add a new `MigrationStep` variant and register it in `MigrationManager::get_migration()` by
+//!    matching on the *current* version.
 //! 3. Ensure the migration is:
 //!    - deterministic,
 //!    - resumable (use `DbMetadata::migration_status` and/or shadow tip),
@@ -115,7 +133,9 @@ use super::{
 };
 
 use crate::{
-    chain_index::{source::BlockchainSource, types::GENESIS_HEIGHT},
+    chain_index::{
+        finalised_state::capability::DbMetadata, source::BlockchainSource, types::GENESIS_HEIGHT,
+    },
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock,
@@ -245,7 +265,7 @@ impl<T: BlockchainSource> MigrationManager<T> {
                     self.source.clone(),
                 )
                 .await?;
-            self.current_version = migration.to_version();
+            self.current_version = migration.to_version::<T>();
         }
 
         Ok(())
@@ -255,17 +275,53 @@ impl<T: BlockchainSource> MigrationManager<T> {
     ///
     /// This must be updated whenever a new supported DB version is introduced. The match is strict:
     /// if a step is missing, migration is aborted rather than attempting an unsafe fallback.
-    fn get_migration(&self) -> Result<impl Migration<T>, FinalisedStateError> {
+    fn get_migration(&self) -> Result<MigrationStep, FinalisedStateError> {
         match (
             self.current_version.major,
             self.current_version.minor,
             self.current_version.patch,
         ) {
-            (0, 0, 0) => Ok(Migration0_0_0To1_0_0),
+            (0, 0, 0) => Ok(MigrationStep::Migration0_0_0To1_0_0(Migration0_0_0To1_0_0)),
+            (1, 0, 0) => Ok(MigrationStep::Migration1_0_0To1_1_0(Migration1_0_0To1_1_0)),
             (_, _, _) => Err(FinalisedStateError::Custom(format!(
                 "Missing migration from version {}",
                 self.current_version
             ))),
+        }
+    }
+}
+
+/// Concrete migration step selector.
+///
+/// Rust cannot return `impl Migration<T>` from a `match` that selects between multiple concrete
+/// migration types. `MigrationStep` is the enum-based dispatch wrapper used by [`MigrationManager`]
+/// to select a step and call `migrate(...)`, and to read the step’s `TO_VERSION`.
+enum MigrationStep {
+    Migration0_0_0To1_0_0(Migration0_0_0To1_0_0),
+    Migration1_0_0To1_1_0(Migration1_0_0To1_1_0),
+}
+
+impl MigrationStep {
+    fn to_version<T: BlockchainSource>(&self) -> DbVersion {
+        match self {
+            MigrationStep::Migration0_0_0To1_0_0(_step) => {
+                <Migration0_0_0To1_0_0 as Migration<T>>::TO_VERSION
+            }
+            MigrationStep::Migration1_0_0To1_1_0(_step) => {
+                <Migration1_0_0To1_1_0 as Migration<T>>::TO_VERSION
+            }
+        }
+    }
+
+    async fn migrate<T: BlockchainSource>(
+        &self,
+        router: Arc<Router>,
+        cfg: BlockCacheConfig,
+        source: T,
+    ) -> Result<(), FinalisedStateError> {
+        match self {
+            MigrationStep::Migration0_0_0To1_0_0(step) => step.migrate(router, cfg, source).await,
+            MigrationStep::Migration1_0_0To1_1_0(step) => step.migrate(router, cfg, source).await,
         }
     }
 }
@@ -465,6 +521,66 @@ impl<T: BlockchainSource> Migration<T> for Migration0_0_0To1_0_0 {
 
         info!("v0.0.0 to v1.0.0 migration complete.");
 
+        Ok(())
+    }
+}
+
+/// Minor migration: v1.0.0 → v1.1.0.
+///
+/// There are **no on-disk schema changes** in this step.
+///
+/// This release updates the *API contract* for compact blocks:
+/// - [`CompactBlockExt`] adds `get_compact_block_stream(...)`.
+/// - Compact block transaction materialization is selected via [`PoolTypeFilter`], which may include
+///   transparent data.
+///
+/// This release also introduces [`MigrationStep`], the enum-based migration dispatcher used by
+/// [`MigrationManager`], to allow selecting between multiple concrete migration implementations.
+///
+/// Because the persisted schema contract is unchanged, this migration only updates the stored
+/// [`DbMetadata::version`] from `1.0.0` to `1.1.0`.
+///
+/// Safety and resumability:
+/// - Idempotent: if run more than once, it will re-write the same metadata.
+/// - No shadow database and no table rebuild.
+/// - Clears any stale in-progress migration status.
+struct Migration1_0_0To1_1_0;
+
+#[async_trait]
+impl<T: BlockchainSource> Migration<T> for Migration1_0_0To1_1_0 {
+    const CURRENT_VERSION: DbVersion = DbVersion {
+        major: 1,
+        minor: 0,
+        patch: 0,
+    };
+
+    const TO_VERSION: DbVersion = DbVersion {
+        major: 1,
+        minor: 1,
+        patch: 0,
+    };
+
+    async fn migrate(
+        &self,
+        router: Arc<Router>,
+        _cfg: BlockCacheConfig,
+        _source: T,
+    ) -> Result<(), FinalisedStateError> {
+        info!("Starting v1.0.0 → v1.1.0 migration (metadata-only).");
+
+        let mut metadata: DbMetadata = router.get_metadata().await?;
+
+        // Preserve the schema hash because there are no schema changes in v1.1.0.
+        // Only advance the version marker to reflect the new API contract.
+        metadata.version = <Self as Migration<T>>::TO_VERSION;
+
+        // Outside of migrations this should be `Empty`. This step performs no build phases, so we
+        // ensure we do not leave a stale in-progress status behind.
+        metadata.migration_status = MigrationStatus::Empty;
+
+        router.update_metadata(metadata).await?;
+
+        info!("v1.0.0 to v1.1.0 migration complete.");
         Ok(())
     }
 }

--- a/zaino-state/src/chain_index/finalised_state/reader.rs
+++ b/zaino-state/src/chain_index/finalised_state/reader.rs
@@ -472,7 +472,7 @@ impl DbReader {
             .await
     }
 
-    async fn get_compact_block_stream(
+    pub(crate) async fn get_compact_block_stream(
         &self,
         start_height: Height,
         end_height: Height,

--- a/zaino-state/src/chain_index/finalised_state/reader.rs
+++ b/zaino-state/src/chain_index/finalised_state/reader.rs
@@ -44,15 +44,17 @@
 //! `DbReader` is created from an `Arc<ZainoDB>` using [`ZainoDB::to_reader`](super::ZainoDB::to_reader).
 //! Prefer passing `DbReader` through query layers rather than passing `ZainoDB` directly.
 
+use zaino_proto::proto::utils::PoolTypeFilter;
+
 use crate::{
     chain_index::{
         finalised_state::capability::CapabilityRequest,
         types::{AddrEventBytes, TransactionHash},
     },
     error::FinalisedStateError,
-    AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, Height, IndexedBlock,
-    OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType,
-    TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
+    AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, CompactBlockStream, Height,
+    IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList,
+    StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
 };
 
 use super::{
@@ -460,14 +462,24 @@ impl DbReader {
     // ***** CompactBlock Ext *****
 
     /// Returns the CompactBlock for the given Height.
-    ///
-    /// TODO: Add separate range fetch method!
     pub(crate) async fn get_compact_block(
         &self,
         height: Height,
+        pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
         self.db(CapabilityRequest::CompactBlockExt)?
-            .get_compact_block(height)
+            .get_compact_block(height, pool_types)
+            .await
+    }
+
+    async fn get_compact_block_stream(
+        &self,
+        start_height: Height,
+        end_height: Height,
+        pool_types: PoolTypeFilter,
+    ) -> Result<CompactBlockStream, FinalisedStateError> {
+        self.db(CapabilityRequest::CompactBlockExt)?
+            .get_compact_block_stream(start_height, end_height, pool_types)
             .await
     }
 }

--- a/zaino-state/src/chain_index/tests/finalised_state/v0.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v0.rs
@@ -287,3 +287,54 @@ async fn get_compact_blocks() {
         println!("CompactBlock at height {height} OK");
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_compact_block_stream() {
+    use futures::StreamExt;
+
+    init_tracing();
+
+    let (TestVectorData { blocks, .. }, _db_dir, _zaino_db, db_reader) =
+        load_vectors_v0db_and_reader().await;
+
+    let start_height = Height(blocks.first().unwrap().height);
+    let end_height = Height(blocks.last().unwrap().height);
+
+    for pool_type_filter in [PoolTypeFilter::default(), PoolTypeFilter::includes_all()] {
+        let compact_block_stream = db_reader
+            .get_compact_block_stream(start_height, end_height, pool_type_filter.clone())
+            .await
+            .unwrap();
+
+        futures::pin_mut!(compact_block_stream);
+
+        let mut expected_next_height_u32: u32 = start_height.0;
+        let mut streamed_block_count: usize = 0;
+
+        while let Some(block_result) = compact_block_stream.next().await {
+            let streamed_compact_block = block_result.unwrap();
+
+            let streamed_height_u32: u32 = u32::try_from(streamed_compact_block.height).unwrap();
+
+            assert_eq!(streamed_height_u32, expected_next_height_u32);
+
+            let singular_compact_block = db_reader
+                .get_compact_block(Height(streamed_height_u32), pool_type_filter.clone())
+                .await
+                .unwrap();
+
+            assert_eq!(singular_compact_block, streamed_compact_block);
+
+            expected_next_height_u32 = expected_next_height_u32.saturating_add(1);
+            streamed_block_count = streamed_block_count.saturating_add(1);
+        }
+
+        let expected_block_count: usize = (end_height
+            .0
+            .saturating_sub(start_height.0)
+            .saturating_add(1)) as usize;
+
+        assert_eq!(streamed_block_count, expected_block_count);
+        assert_eq!(expected_next_height_u32, end_height.0.saturating_add(1));
+    }
+}

--- a/zaino-state/src/chain_index/tests/finalised_state/v0.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v0.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
+use zaino_proto::proto::utils::PoolTypeFilter;
 
 use crate::chain_index::finalised_state::reader::DbReader;
 use crate::chain_index::finalised_state::ZainoDB;
@@ -14,6 +15,7 @@ use crate::chain_index::tests::vectors::{
     build_mockchain_source, load_test_vectors, TestVectorBlockData, TestVectorData,
 };
 use crate::error::FinalisedStateError;
+use crate::local_cache::compact_block_with_pool_types;
 use crate::{BlockCacheConfig, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock};
 
 pub(crate) async fn spawn_v0_zaino_db(
@@ -262,8 +264,26 @@ async fn get_compact_blocks() {
 
         parent_chain_work = *chain_block.index().chainwork();
 
-        let reader_compact_block = db_reader.get_compact_block(Height(*height)).await.unwrap();
-        assert_eq!(compact_block, reader_compact_block);
+        let reader_compact_block_default = db_reader
+            .get_compact_block(Height(*height), PoolTypeFilter::default())
+            .await
+            .unwrap();
+        let default_compact_block = compact_block_with_pool_types(
+            compact_block.clone(),
+            PoolTypeFilter::default().to_pool_types_vector(),
+        );
+        assert_eq!(default_compact_block, reader_compact_block_default);
+
+        let reader_compact_block_all_data = db_reader
+            .get_compact_block(Height(*height), PoolTypeFilter::includes_all())
+            .await
+            .unwrap();
+        let all_data_compact_block = compact_block_with_pool_types(
+            compact_block,
+            PoolTypeFilter::includes_all().to_pool_types_vector(),
+        );
+        assert_eq!(all_data_compact_block, reader_compact_block_all_data);
+
         println!("CompactBlock at height {height} OK");
     }
 }

--- a/zaino-state/src/chain_index/tests/finalised_state/v0.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v0.rs
@@ -270,7 +270,7 @@ async fn get_compact_blocks() {
             .unwrap();
         let default_compact_block = compact_block_with_pool_types(
             compact_block.clone(),
-            PoolTypeFilter::default().to_pool_types_vector(),
+            &PoolTypeFilter::default().to_pool_types_vector(),
         );
         assert_eq!(default_compact_block, reader_compact_block_default);
 
@@ -280,7 +280,7 @@ async fn get_compact_blocks() {
             .unwrap();
         let all_data_compact_block = compact_block_with_pool_types(
             compact_block,
-            PoolTypeFilter::includes_all().to_pool_types_vector(),
+            &PoolTypeFilter::includes_all().to_pool_types_vector(),
         );
         assert_eq!(all_data_compact_block, reader_compact_block_all_data);
 

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -445,7 +445,7 @@ async fn get_compact_blocks() {
             .unwrap();
         let default_compact_block = compact_block_with_pool_types(
             compact_block.clone(),
-            PoolTypeFilter::default().to_pool_types_vector(),
+            &PoolTypeFilter::default().to_pool_types_vector(),
         );
         assert_eq!(default_compact_block, reader_compact_block_default);
 
@@ -455,7 +455,7 @@ async fn get_compact_blocks() {
             .unwrap();
         let all_data_compact_block = compact_block_with_pool_types(
             compact_block,
-            PoolTypeFilter::includes_all().to_pool_types_vector(),
+            &PoolTypeFilter::includes_all().to_pool_types_vector(),
         );
         assert_eq!(all_data_compact_block, reader_compact_block_all_data);
 

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -464,6 +464,57 @@ async fn get_compact_blocks() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn get_compact_block_stream() {
+    use futures::StreamExt;
+
+    init_tracing();
+
+    let (TestVectorData { blocks, .. }, _db_dir, _zaino_db, db_reader) =
+        load_vectors_v1db_and_reader().await;
+
+    let start_height = Height(blocks.first().unwrap().height);
+    let end_height = Height(blocks.last().unwrap().height);
+
+    for pool_type_filter in [PoolTypeFilter::default(), PoolTypeFilter::includes_all()] {
+        let compact_block_stream = db_reader
+            .get_compact_block_stream(start_height, end_height, pool_type_filter.clone())
+            .await
+            .unwrap();
+
+        futures::pin_mut!(compact_block_stream);
+
+        let mut expected_next_height_u32: u32 = start_height.0;
+        let mut streamed_block_count: usize = 0;
+
+        while let Some(block_result) = compact_block_stream.next().await {
+            let streamed_compact_block = block_result.unwrap();
+
+            let streamed_height_u32: u32 = u32::try_from(streamed_compact_block.height).unwrap();
+
+            assert_eq!(streamed_height_u32, expected_next_height_u32);
+
+            let singular_compact_block = db_reader
+                .get_compact_block(Height(streamed_height_u32), pool_type_filter.clone())
+                .await
+                .unwrap();
+
+            assert_eq!(singular_compact_block, streamed_compact_block);
+
+            expected_next_height_u32 = expected_next_height_u32.saturating_add(1);
+            streamed_block_count = streamed_block_count.saturating_add(1);
+        }
+
+        let expected_block_count: usize = (end_height
+            .0
+            .saturating_sub(start_height.0)
+            .saturating_add(1)) as usize;
+
+        assert_eq!(streamed_block_count, expected_block_count);
+        assert_eq!(expected_next_height_u32, end_height.0.saturating_add(1));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn get_faucet_txids() {
     init_tracing();
 

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
+use zaino_proto::proto::utils::PoolTypeFilter;
 
 use crate::chain_index::finalised_state::capability::IndexedBlockExt;
 use crate::chain_index::finalised_state::db::DbBackend;
@@ -17,6 +18,7 @@ use crate::chain_index::tests::vectors::{
 };
 use crate::chain_index::types::TransactionHash;
 use crate::error::FinalisedStateError;
+use crate::local_cache::compact_block_with_pool_types;
 use crate::{
     AddrScript, BlockCacheConfig, BlockMetadata, BlockWithMetadata, ChainWork, Height,
     IndexedBlock, Outpoint,
@@ -437,8 +439,26 @@ async fn get_compact_blocks() {
 
         parent_chain_work = *chain_block.index().chainwork();
 
-        let reader_compact_block = db_reader.get_compact_block(Height(*height)).await.unwrap();
-        assert_eq!(compact_block, reader_compact_block);
+        let reader_compact_block_default = db_reader
+            .get_compact_block(Height(*height), PoolTypeFilter::default())
+            .await
+            .unwrap();
+        let default_compact_block = compact_block_with_pool_types(
+            compact_block.clone(),
+            PoolTypeFilter::default().to_pool_types_vector(),
+        );
+        assert_eq!(default_compact_block, reader_compact_block_default);
+
+        let reader_compact_block_all_data = db_reader
+            .get_compact_block(Height(*height), PoolTypeFilter::includes_all())
+            .await
+            .unwrap();
+        let all_data_compact_block = compact_block_with_pool_types(
+            compact_block,
+            PoolTypeFilter::includes_all().to_pool_types_vector(),
+        );
+        assert_eq!(all_data_compact_block, reader_compact_block_all_data);
+
         println!("CompactBlock at height {height} OK");
     }
 }

--- a/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/zaino-state/src/chain_index/types/db/legacy.rs
@@ -1153,6 +1153,12 @@ impl IndexedBlock {
     }
 
     /// Converts this `IndexedBlock` into a CompactBlock protobuf message using proto v4 format.
+    ///
+    /// NOTE: This method currently includes transparent tx data in the compact block produced,
+    ///       `zaino-state::local_cache::compact_block_with_pool_types` should be used to selectively
+    ///       remove tx data by pool type. Alternatively this method could be updated to take a
+    ///       `zaino-proto::proto::utils::PoolTypeFilter` could be  added as an input to this method,
+    ///       with tx data being added selectively here.
     pub fn to_compact_block(&self) -> zaino_proto::proto::compact_formats::CompactBlock {
         // NOTE: Returns u64::MAX if the block is not in the best chain.
         let height: u64 = self.height().0.into();
@@ -1163,17 +1169,7 @@ impl IndexedBlock {
         let vtx: Vec<zaino_proto::proto::compact_formats::CompactTx> = self
             .transactions()
             .iter()
-            .filter_map(|tx| {
-                let has_shielded = !tx.sapling().spends().is_empty()
-                    || !tx.sapling().outputs().is_empty()
-                    || !tx.orchard().actions().is_empty();
-
-                if !has_shielded {
-                    return None;
-                }
-
-                Some(tx.to_compact_tx(None))
-            })
+            .map(|tx| tx.to_compact_tx(None))
             .collect();
 
         let sapling_commitment_tree_size = self.commitment_tree_data().sizes().sapling();

--- a/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/zaino-state/src/chain_index/types/db/legacy.rs
@@ -1708,6 +1708,23 @@ impl TransparentCompactTx {
     pub fn outputs(&self) -> &[TxOutCompact] {
         &self.vout
     }
+
+    /// Returns Proto CompactTxIn values, omitting the null prevout used by coinbase.
+    pub fn compact_vin(&self) -> Vec<zaino_proto::proto::compact_formats::CompactTxIn> {
+        self.inputs()
+            .iter()
+            .filter(|txin| !txin.is_null_prevout())
+            .map(|txin| txin.to_compact())
+            .collect()
+    }
+
+    /// Returns Proto TxOut values.
+    pub fn compact_vout(&self) -> Vec<zaino_proto::proto::compact_formats::TxOut> {
+        self.outputs()
+            .iter()
+            .map(|txout| txout.to_compact())
+            .collect()
+    }
 }
 
 /// A compact reference to a previously created transparent UTXO being spent.
@@ -1751,6 +1768,14 @@ impl TxInCompact {
     /// coinbase transaction (all-zero txid, index 0xffff_ffff).
     pub fn is_null_prevout(&self) -> bool {
         self.prevout_txid == [0u8; 32] && self.prevout_index == u32::MAX
+    }
+
+    /// Creates a Proto CompactTxIn from this record.
+    pub fn to_compact(&self) -> zaino_proto::proto::compact_formats::CompactTxIn {
+        zaino_proto::proto::compact_formats::CompactTxIn {
+            prevout_txid: self.prevout_txid.to_vec(),
+            prevout_index: self.prevout_index,
+        }
     }
 }
 
@@ -1942,6 +1967,22 @@ impl TxOutCompact {
     /// Returns script type Enum.
     pub fn script_type_enum(&self) -> Option<ScriptType> {
         ScriptType::try_from(self.script_type).ok()
+    }
+
+    /// Creates a Proto TxOut from this record.
+    ///
+    /// Note: this reconstructs standard P2PKH / P2SH scripts. For NonStandard outputs,
+    /// this returns an empty script_pub_key.
+    pub fn to_compact(&self) -> zaino_proto::proto::compact_formats::TxOut {
+        let script_pub_key = self
+            .script_type_enum()
+            .and_then(|script_type| build_standard_script(self.script_hash, script_type))
+            .unwrap_or_default();
+
+        zaino_proto::proto::compact_formats::TxOut {
+            value: self.value,
+            script_pub_key,
+        }
     }
 }
 

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -383,7 +383,7 @@ pub(crate) fn display_txids_to_server(txids: Vec<String>) -> Result<Vec<Vec<u8>>
 /// Note: for backwards compatibility an empty vector will return Sapling and Orchard Tx info.
 pub(crate) fn compact_block_with_pool_types(
     mut block: CompactBlock,
-    pool_types: Vec<PoolType>,
+    pool_types: &[PoolType],
 ) -> CompactBlock {
     if pool_types.is_empty() {
         for compact_tx in &mut block.vtx {


### PR DESCRIPTION
This PR fixes compact block serving in the finalised state. 

Specifically:
- `get_compact_block` has been implemented to only fetch relevant data from the database.
- `get_compact_block_streamer` has been implemented in the database to enable efficient serving of compact block ranges.
- Database migration v1.0.0 -> v1.1.0 has been implemented and documented.
- Database ChangeLog added.
- ZainoDB::get_compact_block_stream tests added

NOTE: This PR does not update the ChainIndex interface as there are currently several other PRs in flight that update that code. Once https://github.com/zingolabs/zaino/pull/788 lands those PRs should update the ChainIndex to use these new methods and API shape.