### PR TITLE
Lightclient protocol Test Fixes

### DIFF
--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -2440,7 +2440,7 @@ mod zebra {
                 max_entries: 0,
             };
             let fetch_service_sapling_subtree_roots = fetch_service_subscriber
-                .get_subtree_roots(sapling_subtree_roots_request.clone())
+                .get_subtree_roots(sapling_subtree_roots_request)
                 .await
                 .unwrap()
                 .map(Result::unwrap)
@@ -2859,7 +2859,7 @@ mod zebra {
         }
 
         #[tokio::test(flavor = "multi_thread")]
-        async fn gat_transparent_data_from_compact_block_when_requested() {
+        async fn get_transparent_data_from_compact_block_when_requested() {
             let (
                 mut test_manager,
                 _fetch_service,
@@ -2902,10 +2902,22 @@ mod zebra {
                 state_service_taddress_balance
             );
 
+            let chain_height = state_service_subscriber
+                .get_latest_block()
+                .await
+                .unwrap()
+                .height;
+
             let compact_block_range = state_service_subscriber
                 .get_block_range(BlockRange {
-                    start: None,
-                    end: None,
+                    start: Some(BlockId {
+                        height: 0,
+                        hash: Vec::new(),
+                    }),
+                    end: Some(BlockId {
+                        height: chain_height,
+                        hash: Vec::new(),
+                    }),
                     pool_types: pool_types_into_i32_vec(
                         [PoolType::Transparent, PoolType::Sapling, PoolType::Orchard].to_vec(),
                     ),

--- a/zaino-proto/src/proto/utils.rs
+++ b/zaino-proto/src/proto/utils.rs
@@ -184,9 +184,9 @@ impl PoolTypeFilter {
 
             // guard against returning an invalid state this shouls never happen.
             if filter.is_empty() {
-                return Ok(Self::default());
+                Ok(Self::default())
             } else {
-                return Ok(filter);
+                Ok(filter)
             }
         }
     }
@@ -301,7 +301,7 @@ mod test {
 
         assert_eq!(
             PoolTypeFilter::new_from_pool_types(&pools),
-            Ok(PoolTypeFilter::from_checked_parts(true, true, false))
+            Ok(PoolTypeFilter::from_checked_parts(true, true, true))
         );
     }
 

--- a/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/zaino-state/src/chain_index/types/db/legacy.rs
@@ -33,7 +33,6 @@ use core2::io::{self, Read, Write};
 use hex::{FromHex, ToHex};
 use primitive_types::U256;
 use std::{fmt, io::Cursor};
-use zaino_proto::proto::compact_formats::{CompactTxIn, TxOut};
 use zebra_chain::serialization::BytesInDisplayOrder as _;
 
 use crate::chain_index::encoding::{

--- a/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/zaino-state/src/chain_index/types/db/legacy.rs
@@ -1467,35 +1467,13 @@ impl CompactTxData {
             )
             .collect();
 
-        let vout = self
-            .transparent
-            .vout
-            .iter()
-            .map(|tx_out| TxOut {
-                value: tx_out.value,
-                script_pub_key: tx_out.script_hash.to_vec(),
-            })
-            .collect();
+        let vout = self.transparent().compact_vout();
 
-        let vin = self
-            .transparent
-            .vin
-            .iter()
-            .filter_map(|t_in| {
-                if t_in.is_null_prevout() {
-                    None
-                } else {
-                    Some(CompactTxIn {
-                        prevout_txid: t_in.prevout_txid.to_vec(),
-                        prevout_index: t_in.prevout_index,
-                    })
-                }
-            })
-            .collect();
+        let vin = self.transparent().compact_vin();
 
         zaino_proto::proto::compact_formats::CompactTx {
             index: self.index(),
-            txid: self.txid().bytes_in_display_order().to_vec(),
+            txid: self.txid().0.to_vec(),
             fee,
             spends,
             outputs,
@@ -1760,7 +1738,7 @@ impl TxInCompact {
         self.prevout_index
     }
 
-    /// `true` iff this input is the special “null” out-point used by a
+    /// `true` if this input is the special “null” out-point used by a
     /// coinbase transaction (all-zero txid, index 0xffff_ffff).
     pub fn is_null_prevout(&self) -> bool {
         self.prevout_txid == [0u8; 32] && self.prevout_index == u32::MAX

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -391,6 +391,13 @@ pub(crate) fn compact_block_with_pool_types(
             compact_tx.vin.clear();
             compact_tx.vout.clear();
         }
+
+        // Omit transactions that have no Sapling/Orchard elements.
+        block.vtx.retain(|compact_tx| {
+            !compact_tx.spends.is_empty()
+                || !compact_tx.outputs.is_empty()
+                || !compact_tx.actions.is_empty()
+        });
     } else {
         for compact_tx in &mut block.vtx {
             // strip out transparent inputs if not Requested
@@ -408,6 +415,15 @@ pub(crate) fn compact_block_with_pool_types(
                 compact_tx.actions.clear();
             }
         }
+
+        // Omit transactions that have no elements in any requested pool type.
+        block.vtx.retain(|compact_tx| {
+            !compact_tx.vin.is_empty()
+                || !compact_tx.vout.is_empty()
+                || !compact_tx.spends.is_empty()
+                || !compact_tx.outputs.is_empty()
+                || !compact_tx.actions.is_empty()
+        });
     }
 
     block


### PR DESCRIPTION
Small code fixes for failing tests:
- get_compact_blocks: Added filter to compact_block_with_pool_types to follow legacy behaviour when default pools selected and to only include tx that have components from any pools specified when pool filter is used. Unified Vin / Vout creation. Removed reversing of txid byte order.
- test_pool_type_filter_t_z_o: Fixed test assert.
- get_transparent_data_from_compact_block_when_requested: Fixed method call.

